### PR TITLE
Add --stdio to process STDIN

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,6 +1,5 @@
 //! Utilities for logging
 
-use crate::Cli;
 use colored::{Color, Colorize};
 use env_logger::Builder;
 use log::Level;
@@ -94,23 +93,10 @@ const fn get_log_color(log_level: Level) -> Color {
     }
 }
 
-/// Parse the log level from the command line arguments
-const fn get_log_level(args: &Cli) -> LevelFilter {
-    if args.trace {
-        LevelFilter::Trace
-    } else if args.verbose {
-        LevelFilter::Info
-    } else if args.quiet {
-        LevelFilter::Error
-    } else {
-        LevelFilter::Warn
-    }
-}
-
 /// Start the logger
-pub fn init_logger(args: &Cli) {
+pub fn init_logger(level_filter: LevelFilter) {
     Builder::new()
-        .filter_level(get_log_level(args))
+        .filter_level(level_filter)
         .format(|buf, record| {
             writeln!(
                 buf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,22 +44,36 @@ const LINE_END: &str = "\r\n";
 
 fn main() {
     let mut args = Cli::parse();
+    init_logger(args.log_level());
+
     args.resolve();
-    init_logger(&args);
     let mut exit_code = 0;
 
-    for file in &args.files {
-        let mut logs = Vec::<Log>::new();
-        if let Some((file, text)) = read(file, &mut logs) {
+    if args.stdin {
+        let mut logs = vec![];
+        if let Some((file, text)) = read_stdin(&mut logs) {
             let new_text = format_file(&text, &file, &args, &mut logs);
             exit_code = process_output(
                 &args, &file, &text, &new_text, exit_code, &mut logs,
             );
         } else {
             exit_code = 1;
-        };
-
+        }
         print_logs(logs);
+    } else {
+        for file in &args.files {
+            let mut logs = vec![];
+            if let Some((file, text)) = read(file, &mut logs) {
+                let new_text = format_file(&text, &file, &args, &mut logs);
+                exit_code = process_output(
+                    &args, &file, &text, &new_text, exit_code, &mut logs,
+                );
+            } else {
+                exit_code = 1;
+            };
+            print_logs(logs);
+        }
     }
+
     exit(exit_code)
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -4,6 +4,7 @@ use crate::logging::*;
 use crate::regexes::*;
 use clap::Parser;
 use log::Level::Error;
+use log::LevelFilter;
 use std::fs;
 
 /// Command line arguments
@@ -24,15 +25,46 @@ pub struct Cli {
     pub quiet: bool,
     #[arg(long, short, help = "Show trace log messages")]
     pub trace: bool,
-    #[arg(required = true)]
+    #[arg(help = "List of files that should be formatted")]
     pub files: Vec<String>,
+    #[arg(
+        long,
+        short,
+        help = "Process STDIN as a single file and output formatted text to STDOUT"
+    )]
+    pub stdin: bool,
 }
 
 impl Cli {
+    /// Get the log level.
+    pub const fn log_level(&self) -> LevelFilter {
+        if self.trace {
+            LevelFilter::Trace
+        } else if self.verbose {
+            LevelFilter::Info
+        } else if self.quiet {
+            LevelFilter::Error
+        } else {
+            LevelFilter::Warn
+        }
+    }
+
     /// Ensure the provided arguments are consistent
     pub fn resolve(&mut self) {
+        use std::process::exit;
+
         if self.trace {
             self.verbose = true;
+        }
+        self.print |= self.stdin;
+
+        if !self.stdin && self.files.is_empty() {
+            log::error!("No files specified, either provide at least one filename or set the --stdin flag.");
+            exit(1);
+        }
+        if self.stdin && !self.files.is_empty() {
+            log::warn!("Provided file name(s) will be ignored when using the --stdin flag.");
+            self.files.clear();
         }
     }
 
@@ -43,6 +75,7 @@ impl Cli {
             print: false,
             keep: false,
             verbose: false,
+            stdin: false,
             quiet: false,
             trace: false,
             files: Vec::<String>::new(),
@@ -68,4 +101,31 @@ pub fn read(file: &str, logs: &mut Vec<Log>) -> Option<(String, String)> {
         record_file_log(logs, Error, file, "File type invalid.");
     }
     None
+}
+
+/// Attempts to read from STDIN and return the filename `<STDIN>` and text.
+pub fn read_stdin(logs: &mut Vec<Log>) -> Option<(String, String)> {
+    use std::io::Read;
+
+    let mut text = String::new();
+    match std::io::stdin().read_to_string(&mut text) {
+        Ok(bytes) => {
+            record_file_log(
+                logs,
+                log::Level::Trace,
+                "<STDIN>",
+                &format!("Read {bytes} bytes."),
+            );
+            Some((String::from("<STDIN>"), text))
+        }
+        Err(e) => {
+            record_file_log(
+                logs,
+                Error,
+                "<STDIN>",
+                &format!("Could not read from STDIN: {e}"),
+            );
+            None
+        }
+    }
 }


### PR DESCRIPTION
This adds the switch `--stdio` which will skip the provided list of files and instead process the text that is provided via stdin. The formatted output is then written to stdout.

The list of files is now no longer a required argument, but within the `Cli::resolve` method, it is ensured that either the `--stdin` flag is set, or at least one file is provided. Also, the method warns if a list of filenames is provided and the `--stdio` flag is set, and then clears the list of files and processes just stdin.

The logging is now initialized a bit earlier in the `main()` method, which allows writing a one-off error message (by invoking `log::error!`/`log::warn!`) within `Cli::resolve`.