### PR TITLE
Remove quadratic complexity from `find_comment_index`

### DIFF
--- a/src/comments.rs
+++ b/src/comments.rs
@@ -2,33 +2,10 @@
 
 /// Find the location where a comment begins in a line
 pub fn find_comment_index(line: &str) -> Option<usize> {
-    // no percent means no comment
-    if !line.contains('%') {
-        return None;
-    }
-
-    let n = line.chars().count();
-
-    // empty line has no comment
-    if n == 0 {
-        return None;
-    }
-
-    // check the first character
-    let mut prev_c: char = line.chars().next().unwrap();
-    if prev_c == '%' {
-        return Some(0);
-    }
-
-    // single-character line
-    if n == 1 {
-        return None;
-    }
-
-    // multi-character line
-    for i in 1..n {
-        let c = line.chars().nth(i).unwrap();
-        if c == '%' && (prev_c == ' ' || prev_c != '\\') {
+    let chars = line.chars();
+    let mut prev_c = ' ';
+    for (i, c) in chars.enumerate() {
+        if c == '%' && prev_c != '\\' {
             return Some(i);
         }
         prev_c = c;


### PR DESCRIPTION
When calling the `.nth()` method on the Chars type ( Char iterator ) one will consume the iterator up to the n-th item and return that item if found https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.nth.

The means that the previous implementation has quadratic complexity in the case of a multi-character line.
This one is linear and will iterator over the line at most one time.

All the previous functionality has been accounted for. The tests pass.
