### PR TITLE
Add overlay output to `flake.nix` via `overlay.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,5 +20,8 @@
           default = pkgs.callPackage ./shell.nix {inherit pkgs;};
         };
       }
-    );
+    )
+    // {
+      overlays.default = import ./overlay.nix;
+    };
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,3 @@
+_: prev: {
+  tex-fmt = prev.callPackage ./default.nix {};
+}


### PR DESCRIPTION
Adds an `overlay.nix` that is provided as an output from `flake.nix`.

Allows using an up-to-date version of `tex-fmt` in end user's Nix flakes without depending on `nixpkgs-unstable`.

Using overlays creates a much cleaner `flake.nix` compared to using the package output directly.

Example:

```nix
{
  description = "...";
  inputs = {
    nixpkgs.url     = "github:NixOS/nixpkgs/24.05";
    tex-fmt.url     = "github:WGUNDERWOOD/tex-fmt";
    flake-utils.url = "github:numtide/flake-utils";
  };
  outputs = {nixpkgs, flake-utils, tex-fmt, ...}:
    flake-utils.lib.eachDefaultSystem (system: 
    let
      pkgs = nixpkgs.legacyPackages.${system}.extend (
        tex-fmt.overlays.default
      );
    in {
      devShells = {
        default = pkgs.mkShell {
          name = "...";
          packages = with pkgs; [
            texlab
            tex-fmt
            ...
          ];
        };
      };
      ...
    });
}
```