### PR TITLE
Different indent insertion logic

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -31,13 +31,21 @@ pub fn format_file(
     let mut old_lines = zip(1.., old_lines);
     let mut queue: Vec<(usize, String)> = vec![];
     let mut new_text = String::with_capacity(text.len());
+    let indent_char = if args.usetabs { "\t" } else { " " };
 
     loop {
         if let Some((linum_old, mut line)) = queue.pop() {
             let pattern = Pattern::new(&line);
             let temp_state: State;
             (line, temp_state) = apply_indent(
-                &line, linum_old, &state, logs, file, args, &pattern,
+                &line,
+                linum_old,
+                &state,
+                logs,
+                file,
+                args,
+                &pattern,
+                indent_char,
             );
             if needs_env_new_line(&line, &temp_state, &pattern) {
                 let env_lines =

--- a/src/indent.rs
+++ b/src/indent.rs
@@ -178,7 +178,9 @@ pub fn apply_indent(
             let n_indent_chars = usize::try_from(indent.visual * args.tab).expect("Both `indent.visual` and `args.tab` should be non-negative integers");
             let mut new_line =
                 String::with_capacity(trimmed_line.len() + n_indent_chars);
-            new_line.insert_str(0, &indent_char.repeat(n_indent_chars));
+            for idx in 0..n_indent_chars {
+                new_line.insert_str(idx, indent_char);
+            }
             new_line.insert_str(n_indent_chars, trimmed_line);
             new_line
         } else {


### PR DESCRIPTION
Hi, while browsing the code looking for something else, I noticed the following lines:

https://github.com/WGUNDERWOOD/tex-fmt/blob/59e9636b363f1952b71660718868caedd7a72c62/src/indent.rs#L176-L183

I think `String::insert()` is O(n) in the length of the string so I wondered if it was possible to avoid calling it several times per line. The code in this PR is a suggestion of how to do this differently which I think does only one O(n) operation, assuming that the runtime of `String::insert_str()` doesn't depend on the length of the slice that is inserted.

All of the tests in the `tests` module were successful on my local fork, but I'd be happy to re-work this if I missed something.

PS. Sorry for the extra line in `.gitignore` that got bundled in.