### PR TITLE
Create test files for moving sectioning commands to their own line

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -100,6 +100,7 @@ fn test_short() {
         //"puthesis.cls",
         //"quiver.sty",
         //"readme.tex",
+        // "sections.tex",
         //"short_document.tex",
         //"tikz_network.sty",
         //"unicode.tex",

--- a/tests/source/sections.tex
+++ b/tests/source/sections.tex
@@ -1,0 +1,3 @@
+\section{Section test}
+
+Sectioning commands should be moved to their own line.\subsection{Result} Even if there are more than one.\subsection{Result 2}

--- a/tests/target/sections.tex
+++ b/tests/target/sections.tex
@@ -1,0 +1,6 @@
+\section{Section test}
+
+Sectioning commands should be moved to their own line.
+\subsection{Result}
+Even if there are more than one.
+\subsection{Result 2}


### PR DESCRIPTION
This PR is related to #13; it adds two test files that capture the expected behaviour for formatting sectioning commands: if such a command is on a line with other text, it should be moved to its own line. This should apply to all sectioning commands present on the same line. However ([as discussed](https://github.com/WGUNDERWOOD/tex-fmt/issues/13#issuecomment-2397125767)), no new empty lines should be added around the new line to which the sectioning command was moved.