### PR TITLE
Implemented a prototype for config file support using figment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "bytemuck"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +144,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +188,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "serde",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +234,16 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "indexmap"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -164,6 +258,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "libc"
+version = "0.2.159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +284,12 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "proc-macro2"
@@ -191,6 +307,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -223,6 +350,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "serde"
+version = "1.0.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "similar"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,11 +407,77 @@ version = "0.4.5"
 dependencies = [
  "clap",
  "colored",
+ "directories",
  "env_logger",
+ "figment",
  "lazy_static",
  "log",
  "regex",
+ "serde",
  "similar",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -269,6 +491,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"
@@ -408,3 +642,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,13 @@ exclude = ["tests/*", "extra/*", "*.nix", ".github/*"]
 [dependencies]
 clap = { version = "4.5.19", features = ["derive"] }
 colored = "2.1.0"
+directories = "5.0"
 env_logger = "0.11.5"
+figment = { version = "0.10", features = ["toml"] }
 lazy_static = "1.5.0"
 log = "0.4.22"
 regex = "1.11.0"
+serde = { version = "1.0", features = ["derive"] }
 similar = "2.6.0"
 
 [profile.release]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 //! Utilities for reading the command line arguments
 
-use crate::logging::*;
+use crate::{logging::*, Config};
 use clap::Parser;
 use log::Level::Error;
 use log::LevelFilter;
@@ -15,100 +15,69 @@ use std::io::Read;
 #[command(version, about)]
 pub struct Cli {
     #[arg(long, short, help = "Check formatting, do not modify files")]
-    pub check: bool,
+    pub check: Option<bool>,
     #[arg(long, short, help = "Print to STDOUT, do not modify files")]
-    pub print: bool,
+    pub print: Option<bool>,
     #[arg(long, short, help = "Keep lines, do not wrap")]
-    pub keep: bool,
+    pub keep: Option<bool>,
     #[arg(long, short, help = "Show info log messages")]
-    pub verbose: bool,
+    pub verbose: Option<bool>,
     #[arg(long, short, help = "Hide warning messages")]
-    pub quiet: bool,
+    pub quiet: Option<bool>,
     #[arg(long, short, help = "Show trace log messages")]
-    pub trace: bool,
+    pub trace: Option<bool>,
     #[arg(help = "List of files to be formatted")]
-    pub files: Vec<String>,
+    pub files: Option<Vec<String>>,
     #[arg(
         long,
         short,
         help = "Process STDIN as a single file, output formatted text to STDOUT"
     )]
-    pub stdin: bool,
-    #[arg(
-        long,
-        help = "Number of spaces to use as tab size",
-        default_value_t = 2
-    )]
-    pub tab: i8,
+    pub stdin: Option<bool>,
+    #[arg(long, help = "Number of spaces to use as tab size")]
+    pub tab: Option<i8>,
     #[arg(long, help = "Use tabs instead of spaces for indentation")]
-    pub usetabs: bool,
-    #[arg(long, help = "Line length for wrapping", default_value_t = 80)]
-    pub wrap: u8,
+    pub usetabs: Option<bool>,
+    #[arg(long, help = "Line length for wrapping")]
+    pub wrap: Option<u8>,
     #[clap(skip)]
-    pub wrap_min: u8,
+    pub wrap_min: Option<u8>,
 }
 
-impl Cli {
-    /// Get the log level
-    pub const fn log_level(&self) -> LevelFilter {
-        if self.trace {
-            LevelFilter::Trace
-        } else if self.verbose {
-            LevelFilter::Info
-        } else if self.quiet {
-            LevelFilter::Error
-        } else {
-            LevelFilter::Warn
-        }
-    }
-
-    /// Ensure the provided arguments are consistent
-    pub fn resolve(&mut self, logs: &mut Vec<Log>) -> u8 {
-        let mut exit_code = 0;
-        self.verbose |= self.trace;
-        self.print |= self.stdin;
-        self.wrap_min = if self.wrap >= 50 {
-            self.wrap - 10
-        } else {
-            self.wrap
-        };
-
-        if !self.stdin && self.files.is_empty() {
-            record_file_log(
-                logs,
-                Error,
-                "",
-                "No files specified. Either provide filenames or provide --stdin.",
-            );
-            exit_code = 1;
-        }
-        if self.stdin && !self.files.is_empty() {
-            record_file_log(
-                logs,
-                Error,
-                "",
-                "Do not provide file name(s) when using --stdin.",
-            );
-            exit_code = 1;
-        }
-        exit_code
-    }
-
-    #[cfg(test)]
-    pub const fn new() -> Self {
+impl Default for Cli {
+    fn default() -> Self {
         Self {
-            check: false,
-            print: false,
-            keep: false,
-            verbose: false,
-            stdin: false,
-            quiet: false,
-            trace: false,
-            files: Vec::<String>::new(),
-            tab: 2,
-            usetabs: false,
-            wrap: 80,
-            wrap_min: 70,
+            check: Some(false),
+            print: Some(false),
+            keep: Some(false),
+            verbose: Some(false),
+            quiet: Some(false),
+            trace: Some(false),
+            files: Some(vec![]),
+            stdin: Some(false),
+            tab: Some(2),
+            usetabs: Some(false),
+            wrap: Some(80),
+            wrap_min: Some(70),
         }
+    }
+}
+
+impl Into<Config> for Cli {
+    fn into(self) -> Config {
+        let mut config = Config::default();
+        config.check = self.check.unwrap_or(false);
+        config.print = self.print.unwrap_or(false);
+        config.keep = self.keep.unwrap_or(false);
+        config.verbose = self.verbose.unwrap_or(false);
+        config.quiet = self.quiet.unwrap_or(false);
+        config.trace = self.trace.unwrap_or(false);
+        config.files = self.files.unwrap_or(vec![]);
+        config.stdin = self.stdin.unwrap_or(false);
+        config.tab = self.tab.unwrap_or(2);
+        config.usetabs = self.usetabs.unwrap_or(false);
+        config.wrap = self.wrap.unwrap_or(80);
+        config.wrap_min = self.wrap_min.unwrap_or(70);
+        config
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,107 @@
+//! Configuration for tex-fmt.
+//! After reading the command line arguments and all config files the struct Config should be created and used for configuring tex-fmt
+
+use crate::logging::*;
+use log::Level::Error;
+use log::LevelFilter;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Config {
+    pub check: bool,
+    pub print: bool,
+    pub keep: bool,
+    pub verbose: bool,
+    pub stdin: bool,
+    pub quiet: bool,
+    pub trace: bool,
+    pub files: Vec<String>,
+    pub tab: i8, // NOTE: why is this an i8?
+    pub usetabs: bool,
+    pub wrap: u8,
+    pub wrap_min: u8,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            check: false,
+            print: false,
+            keep: false,
+            verbose: false,
+            quiet: false,
+            trace: false,
+            files: vec![],
+            stdin: false,
+            tab: 2,
+            usetabs: false,
+            wrap: 80,
+            wrap_min: 70,
+        }
+    }
+}
+
+impl Config {
+    /// Get the log level
+    pub const fn log_level(&self) -> LevelFilter {
+        if self.trace {
+            LevelFilter::Trace
+        } else if self.verbose {
+            LevelFilter::Info
+        } else if self.quiet {
+            LevelFilter::Error
+        } else {
+            LevelFilter::Warn
+        }
+    }
+
+    /// Ensure the provided arguments are consistent
+    pub fn resolve(&mut self, logs: &mut Vec<Log>) -> u8 {
+        let mut exit_code = 0;
+        self.verbose |= self.trace;
+        self.print |= self.stdin;
+        self.wrap_min = if self.wrap >= 50 {
+            self.wrap - 10
+        } else {
+            self.wrap
+        };
+
+        if !self.stdin && self.files.is_empty() {
+            record_file_log(
+                logs,
+                Error,
+                "",
+                "No files specified. Either provide filenames or provide --stdin.",
+            );
+            exit_code = 1;
+        }
+        if self.stdin && !self.files.is_empty() {
+            record_file_log(
+                logs,
+                Error,
+                "",
+                "Do not provide file name(s) when using --stdin.",
+            );
+            exit_code = 1;
+        }
+        exit_code
+    }
+
+    #[cfg(test)]
+    pub const fn new() -> Self {
+        Self {
+            check: false,
+            print: false,
+            keep: false,
+            verbose: false,
+            stdin: false,
+            quiet: false,
+            trace: false,
+            files: Vec::<String>::new(),
+            tab: 2,
+            usetabs: false,
+            wrap: 80,
+            wrap_min: 70,
+        }
+    }
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -8,6 +8,7 @@ use crate::regexes::{ENV_BEGIN, ENV_END, ITEM};
 use crate::subs::*;
 use crate::verbatim::*;
 use crate::wrap::*;
+use crate::Config;
 use crate::LINE_END;
 use log::Level::{Info, Warn};
 use std::iter::zip;
@@ -16,7 +17,7 @@ use std::iter::zip;
 pub fn format_file(
     text: &str,
     file: &str,
-    args: &Cli,
+    args: &Config,
     logs: &mut Vec<Log>,
 ) -> String {
     record_file_log(logs, Info, file, "Formatting started.");

--- a/src/indent.rs
+++ b/src/indent.rs
@@ -7,6 +7,7 @@ use crate::ignore::*;
 use crate::logging::*;
 use crate::regexes::*;
 use crate::verbatim::*;
+use crate::Config;
 use core::cmp::max;
 use log::Level::{Trace, Warn};
 
@@ -116,7 +117,7 @@ pub fn apply_indent(
     state: &State,
     logs: &mut Vec<Log>,
     file: &str,
-    args: &Cli,
+    args: &Config,
     pattern: &Pattern,
     indent_char: &str,
 ) -> (String, State) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,11 @@
 #![allow(clippy::module_name_repetitions)]
 
 use clap::Parser;
+use directories::ProjectDirs;
+use figment::{
+    providers::{Format, Serialized, Toml},
+    Figment,
+};
 use std::fs;
 use std::process::ExitCode;
 
@@ -43,7 +48,80 @@ const LINE_END: &str = "\n";
 const LINE_END: &str = "\r\n";
 
 fn main() -> ExitCode {
-    let mut args = Cli::parse();
+    // parse CLI arguments
+    let cli_args = Cli::parse();
+
+    // initilize default config
+    let default_options = Cli {
+        check: false,
+        print: false,
+        keep: false,
+        verbose: false,
+        stdin: false,
+        quiet: false,
+        trace: false,
+        files: Vec::<String>::new(),
+        tab: 2,
+        usetabs: false,
+        wrap: 80,
+        wrap_min: 70,
+    };
+    // set args to cli. Will be overwritten if config file is found
+    let mut args = cli_args.clone();
+
+    // check for config file and override defaults if found
+    // TODO: find names for qualifier and organization
+    if let Some(project_dirs) = ProjectDirs::from("", "", "tex-fmt") {
+        let config_file = project_dirs.config_dir().join("config.toml");
+        // TODO: also check for local config
+        if config_file.exists() {
+            args = Figment::new()
+                .merge(Serialized::defaults(default_options.clone()))
+                .merge(Toml::file(config_file))
+                // TODO: override with local config if found
+                .extract()
+                .unwrap();
+
+            if cli_args.check != default_options.check {
+                args.check = cli_args.check;
+            }
+            if cli_args.print != default_options.print {
+                args.print = cli_args.print;
+            }
+            // NOTE: If keep is set to true in config file, it can't be set to false with the CLI
+            if cli_args.keep != default_options.keep {
+                args.keep = cli_args.keep;
+            }
+            if cli_args.verbose != default_options.verbose {
+                args.verbose = cli_args.verbose;
+            }
+            if cli_args.stdin != default_options.stdin {
+                args.stdin = cli_args.stdin;
+            }
+            if cli_args.quiet != default_options.quiet {
+                args.quiet = cli_args.quiet;
+            }
+            if cli_args.trace != default_options.trace {
+                args.trace = cli_args.trace;
+            }
+            if cli_args.files != default_options.files {
+                args.files = cli_args.files;
+            }
+            if cli_args.tab != default_options.tab {
+                args.tab = cli_args.tab;
+            }
+            if cli_args.usetabs != default_options.usetabs {
+                args.usetabs = cli_args.usetabs;
+            }
+            if cli_args.wrap != default_options.wrap {
+                args.wrap = cli_args.wrap;
+            }
+            if cli_args.wrap_min != default_options.wrap_min {
+                args.wrap_min = cli_args.wrap_min;
+            }
+        }
+    }
+
     init_logger(args.log_level());
 
     let mut logs = Vec::<Log>::new();

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,13 +5,14 @@ use crate::regexes::*;
 use clap::Parser;
 use log::Level::{Error, Trace};
 use log::LevelFilter;
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::Read;
 
 /// Command line arguments
 #[allow(missing_docs)]
 #[allow(clippy::missing_docs_in_private_items)]
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, Serialize, Deserialize, Clone)]
 #[command(version, about)]
 pub struct Cli {
     #[arg(long, short, help = "Check formatting, do not modify files")]

--- a/src/subs.rs
+++ b/src/subs.rs
@@ -5,6 +5,7 @@ use crate::format::*;
 use crate::logging::*;
 use crate::regexes::*;
 use crate::Cli;
+use crate::Config;
 use crate::LINE_END;
 use log::Level::Trace;
 
@@ -15,7 +16,7 @@ pub fn remove_extra_newlines(text: &str) -> String {
 }
 
 /// Replace tabs with spaces
-pub fn remove_tabs(text: &str, args: &Cli) -> String {
+pub fn remove_tabs(text: &str, args: &Config) -> String {
     let replace = (0..args.tab).map(|_| " ").collect::<String>();
     text.replace('\t', &replace)
 }
@@ -46,7 +47,7 @@ pub fn put_env_new_line(
     line: &str,
     state: &State,
     file: &str,
-    args: &Cli,
+    args: &Config,
     logs: &mut Vec<Log>,
 ) -> Option<(String, String)> {
     if args.trace {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,11 +2,12 @@ use crate::format_file;
 use crate::fs;
 use crate::logging::*;
 use crate::Cli;
+use crate::Config;
 use colored::Colorize;
 use similar::{ChangeTag, TextDiff};
 
 fn test_file(source_file: &str, target_file: &str) -> bool {
-    let args = Cli::new();
+    let args = Config::new();
     let mut logs = Vec::<Log>::new();
     let source_text = fs::read_to_string(source_file).unwrap();
     let target_text = fs::read_to_string(target_file).unwrap();

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -4,10 +4,11 @@ use crate::cli::*;
 use crate::comments::*;
 use crate::format::*;
 use crate::logging::*;
+use crate::Config;
 use log::Level::{Trace, Warn};
 
 /// Check if a line needs wrapping
-pub fn needs_wrap(line: &str, state: &State, args: &Cli) -> bool {
+pub fn needs_wrap(line: &str, state: &State, args: &Config) -> bool {
     !args.keep
         && !state.verbatim.visual
         && !state.ignore.visual
@@ -15,7 +16,7 @@ pub fn needs_wrap(line: &str, state: &State, args: &Cli) -> bool {
 }
 
 /// Find the best place to break a long line
-fn find_wrap_point(line: &str, args: &Cli) -> Option<usize> {
+fn find_wrap_point(line: &str, args: &Config) -> Option<usize> {
     let mut wrap_point: Option<usize> = None;
     let mut after_char = false;
     let mut prev_char: Option<char> = None;
@@ -40,7 +41,7 @@ pub fn apply_wrap(
     line: &str,
     state: &State,
     file: &str,
-    args: &Cli,
+    args: &Config,
     logs: &mut Vec<Log>,
 ) -> Option<(String, String)> {
     if args.trace {

--- a/src/write.rs
+++ b/src/write.rs
@@ -3,6 +3,7 @@
 use crate::cli::*;
 use crate::fs;
 use crate::logging::*;
+use crate::Config;
 use log::Level::Error;
 use std::path;
 
@@ -14,7 +15,7 @@ fn write_file(file: &str, text: &str) {
 
 /// Handle the newly formatted file
 pub fn process_output(
-    args: &Cli,
+    args: &Config,
     file: &str,
     text: &str,
     new_text: &str,


### PR DESCRIPTION
This adresses #39.

To be clear: This is more a proof of concept, than an actual contribution. I don't really know what I'm doing and my rust knowledge is ... limited.

I used [figment](https://docs.rs/figment/latest/figment/index.html) to read in a config file, but I ran into a couple issues:

Figment has support for clap. But the [documentation](https://docs.rs/figment/latest/figment/index.html#for-cli-application-authors) only shows an example, where the config file overwrites the cli, not the other way around.
I am used to cli tools that read configuration in the order `global config -> local config -> cli`, which I find the most intuitive and usable. But clap creates during parsing default values for every argument. And it [doesn't support empty values anymore](https://github.com/clap-rs/clap/issues/1740). So you can't just merge the figments one after another, like shown in the example, because every value would just be overwritten by the `Cli` struct, that was created by `Cli::parse()`.
I "merged" them manually, by just creating a default config `Cli` struct, and then overwriting the config created from the config files with every parameter that wasn't changed via the cli.
Obviously the long list of `if` blocks is really ugly and stupid, but I couldn't think of a better way to do it.
I feel like there should be a way to do this via [figment merge](https://docs.rs/figment/latest/figment/struct.Figment.html#method.merge), but I just couldn't figure it out. Maybe this is a limitation of `clap` `derive`?

**tl;dr**:
`clap` creates a struct with all values. But I only need the values that have changed from the default.

---

Other notes:
- `ProjectDirs::from()` needs [a qualifier and an organization](https://docs.rs/directories/latest/directories/struct.ProjectDirs.html#method.from). I had no idea what to write there
- My implementation currently doesn't check for local configs, but that should be fairly easy to implement. The question is: Should tex-fmt search parent folders? Should there be a `root` option in the config file, like in [editorconfig](https://editorconfig.org/)?
- Currently if you set e.g. `--keep` to true in the config file, you can't overwrite it via the cli, because there is no `--dont-keep` option