### PR TITLE
Alternative formatting processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ dependencies = [
  "log",
  "regex",
  "similar",
+ "unicode-width",
 ]
 
 [[package]]
@@ -263,6 +264,12 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ lazy_static = "1.5.0"
 log = "0.4.22"
 regex = "1.11.0"
 similar = "2.6.0"
+unicode-width = "0.2.0"
 
 [profile.release]
 codegen-units = 1

--- a/notes.org
+++ b/notes.org
@@ -1,1 +1,11 @@
 #+title: tex-fmt
+* Release process
+** Update version number in Cargo.toml
+** Push to GitHub and check tests pass
+** Create a git tag
+*** git tag vX.X.X
+*** git push --tags
+** Publish to crates.io with cargo publish
+** Publish GitHub release with notes
+*** GitHub binaries published automatically with actions
+** Publish in nixpkgs when bot makes pull request

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,12 +1,9 @@
 //! Utilities for reading the command line arguments
 
 use crate::logging::*;
-use crate::regexes::*;
 use clap::Parser;
-use log::Level::{Error, Trace};
+use log::Level::Error;
 use log::LevelFilter;
-use std::fs;
-use std::io::Read;
 
 /// Command line arguments
 #[allow(missing_docs)]
@@ -109,51 +106,6 @@ impl Cli {
             usetabs: false,
             wrap: 80,
             wrap_min: 70,
-        }
-    }
-}
-
-/// Add a missing extension and read the file
-pub fn read(file: &str, logs: &mut Vec<Log>) -> Option<(String, String)> {
-    // check if file has an accepted extension
-    let has_ext = EXTENSIONS.iter().any(|e| file.ends_with(e));
-    // if no valid extension, try adding .tex
-    let mut new_file = file.to_owned();
-    if !has_ext {
-        new_file.push_str(".tex");
-    };
-    if let Ok(text) = fs::read_to_string(&new_file) {
-        return Some((new_file, text));
-    }
-    if has_ext {
-        record_file_log(logs, Error, file, "Could not open file.");
-    } else {
-        record_file_log(logs, Error, file, "File type invalid.");
-    }
-    None
-}
-
-/// Attempt to read from STDIN, return filename `<STDIN>` and text
-pub fn read_stdin(logs: &mut Vec<Log>) -> Option<(String, String)> {
-    let mut text = String::new();
-    match std::io::stdin().read_to_string(&mut text) {
-        Ok(bytes) => {
-            record_file_log(
-                logs,
-                Trace,
-                "<STDIN>",
-                &format!("Read {bytes} bytes."),
-            );
-            Some((String::from("<STDIN>"), text))
-        }
-        Err(e) => {
-            record_file_log(
-                logs,
-                Error,
-                "<STDIN>",
-                &format!("Could not read from STDIN: {e}"),
-            );
-            None
         }
     }
 }

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -16,8 +16,3 @@ pub fn find_comment_index(line: &str) -> Option<usize> {
 pub fn remove_comment(line: &str, comment: Option<usize>) -> &str {
     comment.map_or_else(|| line, |c| &line[0..c])
 }
-
-/// Extract a comment from the end of a line
-pub fn get_comment(line: &str, comment: Option<usize>) -> &str {
-    comment.map_or_else(|| "", |c| &line[c..])
-}

--- a/src/indent.rs
+++ b/src/indent.rs
@@ -1,12 +1,10 @@
 //! Utilities for indenting source lines
 
+use crate::cli::*;
 use crate::comments::*;
 use crate::format::*;
-use crate::ignore::*;
 use crate::logging::*;
-use crate::parse::*;
 use crate::regexes::*;
-use crate::verbatim::*;
 use core::cmp::max;
 use log::Level::{Trace, Warn};
 
@@ -109,78 +107,82 @@ fn get_indent(line: &str, prev_indent: &Indent, pattern: &Pattern) -> Indent {
     Indent { actual, visual }
 }
 
-/// Apply the correct indentation to a line
-pub fn apply_indent(
+/// Calculates the indent for `line` based on its contents. This functions saves the calculated [Indent], which might be
+/// negative, to the given [State], and then ensures that the returned [Indent] is non-negative.
+pub fn calculate_indent(
     line: &str,
-    linum_old: usize,
-    state: &State,
+    state: &mut State,
     logs: &mut Vec<Log>,
     file: &str,
     args: &Cli,
     pattern: &Pattern,
+) -> Indent {
+    // Calculate the new indent by first removing the comment from the line (if there is one) to ignore diffs from
+    // characters in there.
+    let comment_index = find_comment_index(line);
+    let line_strip = remove_comment(line, comment_index);
+    let mut indent = get_indent(line_strip, &state.indent, pattern);
+
+    // Record the indent to the logs.
+    if args.trace {
+        record_line_log(
+            logs,
+            Trace,
+            file,
+            state.linum_new,
+            state.linum_old,
+            line,
+            &format!(
+                "Indent: actual = {}, visual = {}:",
+                indent.actual, indent.visual
+            ),
+        );
+    }
+
+    // Save the indent to the state. Note, this indent might be negative; it is saved without correction so that this is
+    // not forgotten for the next iterations.
+    state.indent = indent.clone();
+
+    // However, we can't negatively indent a line. So we log the negative indent and reset the values to 0.
+    if (indent.visual < 0) || (indent.actual < 0) {
+        record_line_log(
+            logs,
+            Warn,
+            file,
+            state.linum_new,
+            state.linum_old,
+            line,
+            "Indent is negative.",
+        );
+        indent.actual = indent.actual.max(0);
+        indent.visual = indent.visual.max(0);
+    }
+
+    indent
+}
+
+/// Apply the given indentation to a line
+pub fn apply_indent(
+    line: &str,
+    indent: &Indent,
+    args: &Cli,
     indent_char: &str,
-) -> (String, State) {
-    #![allow(clippy::too_many_arguments)]
-    let mut new_state = state.clone();
-    new_state.linum_old = linum_old;
+) -> String {
+    // Remove white space from the start of the line
+    let trimmed_line = line.trim_start();
 
-    new_state.ignore = get_ignore(line, &new_state, logs, file, true);
-    new_state.verbatim =
-        get_verbatim(line, &new_state, logs, file, true, pattern);
-
-    let new_line = if new_state.verbatim.visual || new_state.ignore.visual {
-        line.to_string()
+    // If the line is now empty, return a new empty String
+    if trimmed_line.is_empty() {
+        String::new()
+    // Otherwise, allocate enough memory to fit line with the added indentation and insert the appropriate string slices
     } else {
-        // calculate indent
-        let comment_index = find_comment_index(line);
-        let line_strip = &remove_comment(line, comment_index);
-        let mut indent = get_indent(line_strip, &state.indent, pattern);
-        new_state.indent = indent.clone();
-        if args.trace {
-            record_line_log(
-                logs,
-                Trace,
-                file,
-                state.linum_new,
-                new_state.linum_old,
-                line,
-                &format!(
-                    "Indent: actual = {}, visual = {}:",
-                    indent.actual, indent.visual
-                ),
-            );
+        let n_indent_chars = usize::try_from(indent.visual * args.tab).unwrap();
+        let mut new_line =
+            String::with_capacity(trimmed_line.len() + n_indent_chars);
+        for idx in 0..n_indent_chars {
+            new_line.insert_str(idx, indent_char);
         }
-
-        if (indent.visual < 0) || (indent.actual < 0) {
-            record_line_log(
-                logs,
-                Warn,
-                file,
-                new_state.linum_new,
-                new_state.linum_old,
-                line,
-                "Indent is negative.",
-            );
-            indent.actual = indent.actual.max(0);
-            indent.visual = indent.visual.max(0);
-        }
-
-        // apply indent
-        let trimmed_line = line.trim_start();
-        if trimmed_line.is_empty() {
-            String::new()
-        } else {
-            let n_indent_chars =
-                usize::try_from(indent.visual * args.tab).unwrap();
-            let mut new_line =
-                String::with_capacity(trimmed_line.len() + n_indent_chars);
-            for idx in 0..n_indent_chars {
-                new_line.insert_str(idx, indent_char);
-            }
-            new_line.insert_str(n_indent_chars, trimmed_line);
-            new_line
-        }
-    };
-
-    (new_line, new_state)
+        new_line.insert_str(n_indent_chars, trimmed_line);
+        new_line
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,20 +15,22 @@ use clap::Parser;
 use std::fs;
 use std::process::ExitCode;
 
+mod cli;
 mod comments;
 mod format;
 mod ignore;
 mod indent;
 mod logging;
-mod parse;
+mod read;
 mod regexes;
 mod subs;
 mod verbatim;
 mod wrap;
 mod write;
+use crate::cli::*;
 use crate::format::*;
 use crate::logging::*;
-use crate::parse::*;
+use crate::read::*;
 use crate::write::*;
 
 #[cfg(test)]

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,0 +1,52 @@
+//! Utilities for reading files
+
+use crate::logging::*;
+use crate::regexes::*;
+use log::Level::{Error, Trace};
+use std::fs;
+use std::io::Read;
+
+/// Add a missing extension and read the file
+pub fn read(file: &str, logs: &mut Vec<Log>) -> Option<(String, String)> {
+    // check if file has an accepted extension
+    let has_ext = EXTENSIONS.iter().any(|e| file.ends_with(e));
+    // if no valid extension, try adding .tex
+    let mut new_file = file.to_owned();
+    if !has_ext {
+        new_file.push_str(".tex");
+    };
+    if let Ok(text) = fs::read_to_string(&new_file) {
+        return Some((new_file, text));
+    }
+    if has_ext {
+        record_file_log(logs, Error, file, "Could not open file.");
+    } else {
+        record_file_log(logs, Error, file, "File type invalid.");
+    }
+    None
+}
+
+/// Attempt to read from STDIN, return filename `<STDIN>` and text
+pub fn read_stdin(logs: &mut Vec<Log>) -> Option<(String, String)> {
+    let mut text = String::new();
+    match std::io::stdin().read_to_string(&mut text) {
+        Ok(bytes) => {
+            record_file_log(
+                logs,
+                Trace,
+                "<STDIN>",
+                &format!("Read {bytes} bytes."),
+            );
+            Some((String::from("<STDIN>"), text))
+        }
+        Err(e) => {
+            record_file_log(
+                logs,
+                Error,
+                "<STDIN>",
+                &format!("Could not read from STDIN: {e}"),
+            );
+            None
+        }
+    }
+}

--- a/src/regexes.rs
+++ b/src/regexes.rs
@@ -51,4 +51,17 @@ lazy_static! {
         Regex::new(r"(?P<prev>\S.*?)(?P<env>\\end\{)").unwrap();
     pub static ref RE_ITEM_SHARED_LINE: Regex =
         Regex::new(r"(?P<prev>\S.*?)(?P<env>\\item)").unwrap();
+    // Regex that matches any splitting command with non-whitespace characters before it and catches the previous text
+    // in a group called "prev" and captures the command itself and the remaining text in a group called "env".
+    pub static ref RE_ENV_ITEM_SHARED_LINE: Regex = Regex::new(
+        r"(?x)              # Enable extended mode
+        (?P<prev>\S.*?)     # <prev>: captures any number of characters starting with a non-whitespace
+                            # character until the start of the next group;
+        (?P<env>(           # <env>: captures any LaTeX command before which the line should be split
+            \\begin\{       # start of environments
+            |\\end\{        # end of environments
+            |\\item )       # list items (note the space before the closing bracket)
+        .*)"                // and any characters that follow the command
+    )
+    .unwrap();
 }

--- a/src/subs.rs
+++ b/src/subs.rs
@@ -31,24 +31,58 @@ pub fn needs_env_new_line(
     state: &State,
     pattern: &Pattern,
 ) -> bool {
-    !state.verbatim.visual
+    // Check if we should format this line and if we've matched an environment.
+    let not_ignored_and_contains_env = !state.verbatim.visual
         && !state.ignore.visual
         && (pattern.contains_env_begin
             || pattern.contains_env_end
             || pattern.contains_item)
         && (RE_ENV_BEGIN_SHARED_LINE.is_match(line)
             || RE_ENV_END_SHARED_LINE.is_match(line)
-            || RE_ITEM_SHARED_LINE.is_match(line))
+            || RE_ITEM_SHARED_LINE.is_match(line));
+
+    // If we're not ignoring and we've matched an environment ...
+    if not_ignored_and_contains_env {
+        // ... return `true` if the comment index is `None` (which implies the split point must be in text), otherwise
+        // compare the index of the comment with the split point.
+        find_comment_index(line).map_or(true, |comment_index| {
+            if RE_ENV_ITEM_SHARED_LINE
+                .captures(line)
+                .unwrap() // Doesn't panic because we've matched split point.
+                .get(2)
+                .unwrap() // Doesn't panic because the regex has 4 groups so index 2 is in bounds.
+                .start()
+                > comment_index
+            {
+                // If the split point is past the comment index, then we don't split the line,
+                false
+            } else {
+                // otherwise, the split point is before the comment and we do split the line.
+                true
+            }
+        })
+    } else {
+        // If we're ignoring or we didn't match an environment, we don't need a new line.
+        false
+    }
 }
 
-/// Ensure LaTeX environments begin on new lines
-pub fn put_env_new_line(
-    line: &str,
+/// Ensure LaTeX environments begin on new lines.
+///
+/// Returns a tuple containing:
+/// 1. a reference to the line that was given, shortened because of the split
+/// 2. a reference to the part of the line that was split
+pub fn put_env_new_line<'a>(
+    line: &'a str,
     state: &State,
     file: &str,
     args: &Cli,
     logs: &mut Vec<Log>,
-) -> Option<(String, String)> {
+) -> (&'a str, &'a str) {
+    let captures = RE_ENV_ITEM_SHARED_LINE.captures(line).unwrap();
+
+    let (line, [prev, rest, _]) = captures.extract();
+
     if args.trace {
         record_line_log(
             logs,
@@ -60,31 +94,5 @@ pub fn put_env_new_line(
             "Placing environment on new line.",
         );
     }
-    let comment_index = find_comment_index(line);
-    let comment = get_comment(line, comment_index);
-    let mut text = remove_comment(line, comment_index);
-    let mut temp = RE_ENV_BEGIN_SHARED_LINE
-        .replace(text, format!("$prev{LINE_END}$env"))
-        .to_string();
-    text = &temp;
-    if !text.contains(LINE_END) {
-        temp = RE_ENV_END_SHARED_LINE
-            .replace(text, format!("$prev{LINE_END}$env"))
-            .to_string();
-        text = &temp;
-    }
-    if !text.contains(LINE_END) {
-        temp = RE_ITEM_SHARED_LINE
-            .replace(text, format!("$prev{LINE_END}$env"))
-            .to_string();
-        text = &temp;
-    }
-    if text.contains(LINE_END) {
-        let split = text.split_once(LINE_END).unwrap();
-        let split_0 = split.0.to_string();
-        let mut split_1 = split.1.to_string();
-        split_1.push_str(comment);
-        return Some((split_0, split_1));
-    }
-    None
+    (prev, rest)
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -51,16 +51,14 @@ fn read_files_from_dir(dir: &str) -> Vec<String> {
 #[test]
 fn test_source() {
     let source_files = read_files_from_dir("./tests/source/");
-    let mut fail = false;
     for file in source_files {
         if !test_file(
             &format!("tests/source/{file}"),
             &format!("tests/target/{file}"),
         ) {
-            fail = true;
+            panic!("Failed in {file}");
         }
     }
-    assert!(!fail, "Some tests failed");
 }
 
 #[test]

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -1,26 +1,50 @@
 //! Utilities for wrapping long lines
 
+use crate::cli::*;
 use crate::comments::*;
 use crate::format::*;
 use crate::logging::*;
-use crate::parse::*;
 use log::Level::{Trace, Warn};
+use unicode_width::UnicodeWidthChar;
+
+/// String slice to start wrapped text lines
+pub const TEXT_LINE_START: &str = "";
+/// String slice to start wrapped comment lines
+pub const COMMENT_LINE_START: &str = "% ";
 
 /// Check if a line needs wrapping
-pub fn needs_wrap(line: &str, state: &State, args: &Cli) -> bool {
+pub fn needs_wrap(line: &str, indent_length: usize, args: &Cli) -> bool {
     !args.keep
-        && !state.verbatim.visual
-        && !state.ignore.visual
-        && (line.chars().count() > args.wrap.into())
+        && ({
+            let mut line_length = 0;
+            for c in line.chars() {
+                line_length +=
+                    c.width().expect("Why control character in text?");
+            }
+            line_length
+        } + indent_length
+            > args.wrap.into())
 }
 
 /// Find the best place to break a long line
-fn find_wrap_point(line: &str, args: &Cli) -> Option<usize> {
+fn find_wrap_point(
+    line: &str,
+    indent_length: usize,
+    args: &Cli,
+) -> Option<usize> {
     let mut wrap_point: Option<usize> = None;
     let mut after_char = false;
     let mut prev_char: Option<char> = None;
-    for (i, c) in line.chars().enumerate() {
-        if i >= args.wrap_min.into() && wrap_point.is_some() {
+
+    let mut line_width = 0;
+
+    let wrap_boundary = usize::from(args.wrap_min) - indent_length;
+
+    // Return *byte* index rather than *char* index.
+    for (i, c) in line.char_indices() {
+        line_width += c.width().expect("No control characters in text.");
+
+        if line_width > wrap_boundary && wrap_point.is_some() {
             break;
         }
         if c == ' ' && prev_char != Some('\\') {
@@ -36,13 +60,14 @@ fn find_wrap_point(line: &str, args: &Cli) -> Option<usize> {
 }
 
 /// Wrap a long line into a short prefix and a suffix
-pub fn apply_wrap(
-    line: &str,
+pub fn apply_wrap<'a>(
+    line: &'a str,
+    indent_length: usize,
     state: &State,
     file: &str,
     args: &Cli,
     logs: &mut Vec<Log>,
-) -> Option<(String, String)> {
+) -> Option<[&'a str; 3]> {
     if args.trace {
         record_line_log(
             logs,
@@ -54,7 +79,7 @@ pub fn apply_wrap(
             "Wrapping long line.",
         );
     }
-    let wrap_point = find_wrap_point(line, args);
+    let wrap_point = find_wrap_point(line, indent_length, args);
     let comment_index = find_comment_index(line);
 
     match wrap_point {
@@ -73,11 +98,15 @@ pub fn apply_wrap(
     };
 
     wrap_point.map(|p| {
-        let line_start =
-            comment_index.map_or("", |c| if p > c { "%" } else { "" });
-        let line_1: String = line.chars().take(p).collect();
-        let mut line_2: String = line.chars().skip(p).collect();
-        line_2.insert_str(0, line_start);
-        (line_1, line_2)
+        let this_line = &line[0..p];
+        let next_line_start = comment_index.map_or("", |c| {
+            if p > c {
+                COMMENT_LINE_START
+            } else {
+                TEXT_LINE_START
+            }
+        });
+        let next_line = &line[p + 1..];
+        [this_line, next_line_start, next_line]
     })
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,8 +1,8 @@
 //! Utilities for writing formatted files
 
+use crate::cli::*;
 use crate::fs;
 use crate::logging::*;
-use crate::parse::*;
 use log::Level::Error;
 use std::path;
 

--- a/tests/source/environment_lines.tex
+++ b/tests/source/environment_lines.tex
@@ -21,7 +21,7 @@
 \end{env2} \end{env1}
 
 % environments all on same line
-\begin{env1}\begin{env2}\end{env2}\end{env1} % with a comment
+\begin{env1}\begin{env2}\end{env2}\end{env1} % with a comment \begin{env1}
 
 % environments with extra brackets
 \begin{env1}(a)(b \begin{env2}[c{d}e] \end{env2}[f]g)\end{env1}

--- a/tests/target/environment_lines.tex
+++ b/tests/target/environment_lines.tex
@@ -28,7 +28,7 @@
 \begin{env1}
   \begin{env2}
   \end{env2}
-\end{env1} % with a comment
+\end{env1} % with a comment \begin{env1}
 
 % environments with extra brackets
 \begin{env1}(a)(b


### PR DESCRIPTION
Hi there, as I was tinkering to figure out how to wrap closer to the given wrapping parameter one thing led to another and I arrived at an alternative logic for some of the steps that the formatting loop makes. I thought I'd share the code here in case you would be interested; if there are particular changes you like, I would be happy to cherry-pick them into their own PR and close this one up for the archives.

All the changes in this PR are to the logic only and not to the formatting style, all tests still pass unchanged (save for the addition of a `\begin{env1}` inside a comment to check that it is properly ignored). However, with these changes, I think that wrapping tightly to the wrapping parameter can be achieved by changing the `wrapping_boundary` to use `args.wrap` instead of `args.wrap_min`. I'm still testing this on another branch, but this requires changing all the test file to account for the tighter expected wrap.

### Summary of changes

1. The main formatting loop processes (splits and wraps) lines only by reference, allocating new memory only when applying the indentation, or when returning lines to the queue after wrapping them. 
2. To avoid allocating when indenting only to return the line to the queue without adding it to the text, calculating the indent is separated from applying the indent. This allows moving the indent application until after the wrapping computation.
3. Since the indent is no longer applied to the line before wrapping it, the wrapping logic is expanded to instead take into account the calculated indent when deciding whether a line needs to be wrapped and, if so, where it should be wrapped.
4. Since some languages have 0-width chars (such as the French accents \`,´,ˆ, etc.), I suspect that going with `.chars()` could cause inconsistent wrapping in non-English languages. This code introduces the `unicode-width` dependency to obtain the on-screen width of each character in the string and calculate a wrapping point that visually matches the wrapping parameter.
5. The splitting of lines is done with a new capturing regex from which the index of the matches can be extracted. This then allows returning two string slices: one containing everything before the split point, and the other containing the rest. This Regex could be easily expanded to capture other commands at which the line should be split (such as `\section{...}` or `\[` for example).
6. The wrapping of lines is also done by reference by returning a string slice for the line before the wrap point, a slice containing the start of the next line (to add `"% "` in front of comments), and a slice containing the rest of the line.

### Misc changes

1. Cleaning the text (removing tabs and trailing whitespace) is extracted into a function.
2. Deciding whether to ignore a line (based on verbatim environments or `tex-fmt` ignore commands) is extracted into a function, and checked before proceeding to the formatting logic.
3. Checking whether formatting returns to zero is done by checking the value of `indent.actual` after exiting the loop instead of accessing the lines of the text.
4. The `test_source()` function is modified slightly to panic on the first file that formats incorrectly and to print the file name. The computation of the diff was taking a very long time when many files were failing because of many diffs.

### Performance Report

As show from the output below, these changes bring a (63.0 -> 57.1 = ) 9.3% improvement in performance on my machine.

```
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
Building release binary
   Compiling tex-fmt v0.4.5 (/Users/cyprien/Code/tex-fmt)
    Finished `release` profile [optimized] target(s) in 11.74s
Running benchmark
Benchmark 1: tex-fmt-main
  Time (mean ± σ):      63.0 ms ±   0.7 ms    [User: 58.7 ms, System: 3.8 ms]
  Range (min … max):    62.4 ms …  72.6 ms    200 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs.
 
branch 'pr-refactor-logic' set up to track 'origin/pr-refactor-logic'.
Switched to a new branch 'pr-refactor-logic'
Building release binary
  Downloaded unicode-width v0.2.0
  Downloaded 1 crate (271.5 KB) in 0.21s
   Compiling unicode-width v0.2.0
   Compiling tex-fmt v0.4.5 (/Users/cyprien/Code/tex-fmt)
    Finished `release` profile [optimized] target(s) in 11.78s
Running benchmark
Benchmark 1: tex-fmt-branch
  Time (mean ± σ):      57.1 ms ±   0.5 ms    [User: 53.0 ms, System: 3.8 ms]
  Range (min … max):    56.5 ms …  61.6 ms    200 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs.
 
tex-fmt-main: 0.062972017995s
tex-fmt-branch: 0.05712572198499997s
```
