### PR TITLE
Add comment environment to the list of verbatim environments

### DIFF
--- a/src/regexes.rs
+++ b/src/regexes.rs
@@ -27,7 +27,7 @@ const LISTS: [&str; 5] = [
 ];
 
 /// Names of LaTeX verbatim environments
-const VERBATIMS: [&str; 4] = ["verbatim", "Verbatim", "lstlisting", "minted"];
+const VERBATIMS: [&str; 5] = ["verbatim", "Verbatim", "lstlisting", "minted", "comment"];
 
 // Regexes
 lazy_static! {


### PR DESCRIPTION
The list of verbatim environments doesn't include "comment", so it ends up messing up the formatting of comments (which I like to indent).