### PR TITLE
Remove ignore check from new line checking

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -54,7 +54,7 @@ pub fn format_file(
             ) {
                 // Check if the line should be split because of a pattern
                 // that should begin on a new line.
-                if needs_env_new_line(&line, &temp_state, &pattern) {
+                if needs_env_new_line(&line, &pattern) {
                     // Split the line into two ...
                     let (this_line, next_line) =
                         put_env_new_line(&line, &temp_state, file, args, logs);

--- a/src/subs.rs
+++ b/src/subs.rs
@@ -26,23 +26,17 @@ pub fn remove_trailing_spaces(text: &str) -> String {
 }
 
 /// Check if environment should be split onto a new line
-pub fn needs_env_new_line(
-    line: &str,
-    state: &State,
-    pattern: &Pattern,
-) -> bool {
+pub fn needs_env_new_line(line: &str, pattern: &Pattern) -> bool {
     // Check if we should format this line and if we've matched an environment.
-    let not_ignored_and_contains_env = !state.verbatim.visual
-        && !state.ignore.visual
-        && (pattern.contains_env_begin
-            || pattern.contains_env_end
-            || pattern.contains_item)
+    let contains_splittable_env = (pattern.contains_env_begin
+        || pattern.contains_env_end
+        || pattern.contains_item)
         && (RE_ENV_BEGIN_SHARED_LINE.is_match(line)
             || RE_ENV_END_SHARED_LINE.is_match(line)
             || RE_ITEM_SHARED_LINE.is_match(line));
 
     // If we're not ignoring and we've matched an environment ...
-    if not_ignored_and_contains_env {
+    if contains_splittable_env {
         // ... return `true` if the comment index is `None`
         // (which implies the split point must be in text), otherwise
         // compare the index of the comment with the split point.


### PR DESCRIPTION
Since `needs_env_new_line()` is only called when the line is not ignored, it does not need to check the ignoring flags. This short PR trims the code to achieve this.