### PR TITLE
Fix a bug when list environments is not specified in the config file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -117,7 +117,7 @@ pub fn get_config_args(args: &OptionArgs) -> Option<OptionArgs> {
         lists: config
             .get("lists")
             .and_then(|v| v.as_array())
-            .unwrap()
+            .unwrap_or(&vec![])
             .iter()
             .filter_map(|v| v.as_str().map(String::from))
             .collect(),


### PR DESCRIPTION
When the `lists` argument is not specified in the `tex-fmt.toml` (in my workspace, `tex-fmt.toml` only has `wrap = false`), `unwrap()` will cause a panic at `src/config.rs:120:14`.

P.S. I'm still learning Rust, so I may not be aware of the most optimal solution.