### PR TITLE
Create pre-commit hook for running tex-fmt

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
 - id: tex-fmt
-  name: Format latex files
+  name: Format LaTeX files
   language: rust
   entry: tex-fmt
   args: [--fail-on-change]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,7 @@
 - id: tex-fmt
   name: Format latex files
   language: rust
-  entry: tex-fmt --fail-on-change
+  entry: tex-fmt
+  args: [--fail-on-change]
   files: \.(tex|bib|cls|sty)$
   stages: [pre-commit, pre-merge-commit, pre-push, manual]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: tex-fmt
+  name: Format latex files
+  language: rust
+  entry: tex-fmt --fail-on-change
+  files: \.(tex|bib|cls|sty)$
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ A man page can be generated at run-time using the
 [man](https://github.com/WGUNDERWOOD/tex-fmt/tree/main/man)
 directory for more details.
 
-### Run before every commit
+### Pre-commit hook
 
 You can format your LaTeX files before every commit using
 [pre-commit](http://pre-commit.com) with the following `.pre-commit-config.yaml`

--- a/README.md
+++ b/README.md
@@ -227,6 +227,23 @@ A man page can be generated at run-time using the
 [man](https://github.com/WGUNDERWOOD/tex-fmt/tree/main/man)
 directory for more details.
 
+### Run before every commit
+
+You can format your LaTeX files before every commit using
+[pre-commit](http://pre-commit.com) with the following `.pre-commit-config.yaml`
+in your repository root:
+
+```yaml
+repos:
+  - repo: https://github.com/WGUNDERWOOD/tex-fmt
+    rev: v0.5.3
+    hooks:
+      - id: tex-fmt
+```
+
+For more on how to use pre-commit check out their
+[quick start guide](https://pre-commit.com/#quick-start)!
+
 ## Performance
 
 When formatting all of the test cases,

--- a/README.md
+++ b/README.md
@@ -241,6 +241,14 @@ repos:
       - id: tex-fmt
 ```
 
+If you don't only want to prevent committing on unformatted
+documents but don't want them automatically formatted, add:
+
+```yaml
+      - id: tex-fmt
+        args: [--check]
+```
+
 For more on how to use pre-commit check out their
 [quick start guide](https://pre-commit.com/#quick-start)!
 


### PR DESCRIPTION
# What I did

I wanted to create a hook for [pre-commit](https://pre-commit.org) to format my LaTeX files on every commit, however this requires that the hook return a non-0 exit code when modifying the supplied files. So I created the `--fail-on-change` flag that simply formats the files and returns 1 when any of them changed -- like some kind of hybrid between `--check` and no `--check`.

While I was making my changes I also found a bug when running with multiple files which I fixed (more in the commit message of ea3460b32688df8e383c830f2021eba390a72a4b). 

# How to try

You can either use the method written [here](https://pre-commit.com/#developing-hooks-interactively) or use it from my repo with the following `.pre-commit-config.yaml`:
```yaml
repos:
-   repo: https://github.com/bnctth/tex-fmt
    rev: 60472ef651e6dd6a827759a88e10e49f7ce750f9
    hooks:
    -   id: tex-fmt
```
