### PR TITLE
Add option --fail-on-change

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,0 @@
-- id: tex-fmt
-  name: Format latex files
-  language: rust
-  entry: tex-fmt --fail-on-change
-  files: \.(tex|bib|cls|sty)$
-  stages: [pre-commit, pre-merge-commit, pre-push, manual]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: tex-fmt
+  name: Format latex files
+  language: rust
+  entry: tex-fmt --fail-on-change
+  files: \.(tex|bib|cls|sty)$
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]

--- a/README.md
+++ b/README.md
@@ -157,12 +157,13 @@ https://github.com/WGUNDERWOOD/tex-fmt?tab=readme-ov-file#options)
 section below.
 
 ``` shell
-tex-fmt file.tex             # format file.tex and overwrite
-tex-fmt --check file.tex     # check if file.tex is correctly formatted
-tex-fmt --print file.tex     # format file.tex and print to stdout
-tex-fmt --nowrap file.tex    # do not wrap long lines
-tex-fmt --stdin              # read from stdin and print to stdout
-tex-fmt --help               # view help information
+tex-fmt file.tex                  # format file.tex and overwrite
+tex-fmt --check file.tex          # check if file.tex is correctly formatted
+tex-fmt --print file.tex          # format file.tex and print to stdout
+tex-fmt --fail-on-change file.tex # format file.tex and return exit-code 1 if overwritten 
+tex-fmt --nowrap file.tex         # do not wrap long lines
+tex-fmt --stdin                   # read from stdin and print to stdout
+tex-fmt --help                    # view help information
 ```
 
 ### Configuration

--- a/src/args.rs
+++ b/src/args.rs
@@ -17,6 +17,8 @@ pub struct Args {
     pub check: bool,
     /// Print to stdout, do not modify files
     pub print: bool,
+    /// Return non-0 exit code when modifying files
+    pub fail_on_change: bool,
     /// Wrap long lines
     pub wrap: bool,
     /// Maximum allowed line length
@@ -47,6 +49,7 @@ pub struct Args {
 pub struct OptionArgs {
     pub check: Option<bool>,
     pub print: Option<bool>,
+    pub fail_on_change: Option<bool>,
     pub wrap: Option<bool>,
     pub wraplen: Option<u8>,
     pub wrapmin: Option<u8>,
@@ -85,6 +88,7 @@ impl Default for OptionArgs {
         Self {
             check: Some(false),
             print: Some(false),
+            fail_on_change: Some(false),
             wrap: Some(true),
             wraplen: Some(80),
             wrapmin: Some(70),
@@ -128,6 +132,7 @@ impl Args {
         Self {
             check: args.check.unwrap(),
             print: args.print.unwrap(),
+            fail_on_change: args.fail_on_change.unwrap(),
             wrap: args.wrap.unwrap(),
             wraplen: args.wraplen.unwrap(),
             wrapmin: args.wrapmin.unwrap(),
@@ -216,6 +221,7 @@ impl fmt::Display for Args {
         write!(f, "{}", "tex-fmt".magenta().bold())?;
         display_arg_line(f, "check", &self.check.to_string())?;
         display_arg_line(f, "print", &self.print.to_string())?;
+        display_arg_line(f, "fail-on-change", &self.print.to_string())?;
         display_arg_line(f, "wrap", &self.wrap.to_string())?;
         display_arg_line(f, "wraplen", &self.wraplen.to_string())?;
         display_arg_line(f, "wrapmin", &self.wrapmin.to_string())?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,7 @@ pub fn get_cli_args() -> OptionArgs {
     let args = OptionArgs {
         check: get_flag(&arg_matches, "check"),
         print: get_flag(&arg_matches, "print"),
+        fail_on_change: get_flag(&arg_matches,"fail-on-change"),
         wrap,
         wraplen: arg_matches.get_one::<u8>("wraplen").copied(),
         wrapmin: None,

--- a/src/command.rs
+++ b/src/command.rs
@@ -25,6 +25,13 @@ fn get_cli_command() -> Command {
                 .help("Print to stdout, do not modify files"),
         )
         .arg(
+            Arg::new("fail-on-change")
+                .short('f')
+                .long("fail-on-change")
+                .action(SetTrue)
+                .help("Format files and return non-zero exit code when modifying files")
+        )
+        .arg(
             Arg::new("nowrap")
                 .short('n')
                 .long("nowrap")

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,6 +112,9 @@ pub fn get_config_args(
     let args = OptionArgs {
         check: config.get("check").map(|x| x.as_bool().unwrap()),
         print: config.get("print").map(|x| x.as_bool().unwrap()),
+        fail_on_change: config
+            .get("fail-on-change")
+            .map(|x| x.as_bool().unwrap()),
         wrap: config.get("wrap").map(|x| x.as_bool().unwrap()),
         wraplen: config
             .get("wraplen")

--- a/src/format.rs
+++ b/src/format.rs
@@ -273,7 +273,7 @@ pub fn run(args: &Args, logs: &mut Vec<Log>) -> u8 {
         for file in &args.files {
             if let Some((file, text)) = read(file, logs) {
                 let new_text = format_file(&text, &file, args, logs);
-                exit_code = process_output(args, &file, &text, &new_text, logs);
+                exit_code |= process_output(args, &file, &text, &new_text, logs);
             } else {
                 exit_code = 1;
             }

--- a/src/write.rs
+++ b/src/write.rs
@@ -2,7 +2,7 @@
 
 use crate::args::*;
 use crate::logging::*;
-use log::Level::Error;
+use log::Level::{Error, Info};
 use std::fs;
 use std::path;
 
@@ -27,6 +27,10 @@ pub fn process_output(
         return 1;
     } else if text != new_text {
         write_file(file, new_text);
+        if args.fail_on_change {
+            record_file_log(logs, Info, file, "Fixed incorrect formatting.");
+            return 1;
+        }
     }
     0
 }


### PR DESCRIPTION
This is a prerequisite for #81.

I created the `--fail-on-change` flag, that when used combines the behavior of no flag and `--check`: it does overwrite the formatted files but also returns exit-code 1 if the input file was not formatted.

Also while I was making my changes I also found a bug when running with multiple files, in which case only the exit-code determined by the last file was returned. This would also interfere with the workings of `--fail-on-change` so I believe this -- single character -- fix is in scope for this PR.