### PR TITLE
Add bibtex-tidy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,9 @@ Alternatively, you can
 - [latexindent](https://github.com/cmhughes/latexindent.pl).
 Perl script, many configuration options, slow on large files
 
+- [bibtex-tidy](https://github.com/FlamingTempura/bibtex-tidy).
+JavaScript program, specifically for BibTeX files
+
 - [LaTeXTidy](http://bfc.sfsu.edu/cgi-bin/hsu.pl?LaTeX_Tidy).
 Perl script, download links seem to be broken
 


### PR DESCRIPTION
Hi! I want to change readme to add one of the other formatting tools I use: [bibtex-tidy](https://github.com/FlamingTempura/bibtex-tidy). tex-fmt does support BibTeX files, but bibtex-tidy program seems to be much more versatile on edge cases. Just want to share with others. 