### PR TITLE
Add tex-fmt GitHub Action to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ through one of the above methods.
 A package for Neovim is provided by
 [mason.nvim](https://github.com/williamboman/mason.nvim).
 
+### GitHub Action
+
+The [tex-fmt-action](https://github.com/grayespinoza/tex-fmt-action) can install and run tex-fmt.
+
 ## Usage
 
 The most commonly used options are given below.


### PR DESCRIPTION
Hey! I thought it would be convenient, so I wrote up a GitHub Action for tex-fmt and wanted to add it to the README.

[tex-fmt-action](https://github.com/grayespinoza/tex-fmt-action)