### PR TITLE
Allow custom non-indented environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,16 +358,17 @@ The following arguments can be passed on the command line.
 The following arguments can be provided in `tex-fmt.toml`.
 The first example in each row is the default value.
 
-| Option           | Type     | Examples              | Description |
-| ---------------- | -------- | --------------------- | --- |
-| `check`          | bool     | `false`               | Check formatting, do not modify files |
-| `print`          | bool     | `false`               | Print to stdout, do not modify files |
-| `fail-on-change` | bool     | `false`               | Fail if files are modified |
-| `wrap`           | bool     | `true`                | Wrap long lines |
-| `wraplen`        | int      | `80`, `100`           | Line length for wrapping |
-| `wrapmin`        | int      | `70`, `90`            | Target minimum length for line wrapping |
-| `tabsize`        | int      | `2`, `4`              | Number of characters to use as tab size |
-| `tabchar`        | str      | `"space"`, `"tab"`    | Character to use for indentation |
-| `stdin`          | bool     | `false`               | Process stdin as a single file, output to stdout |
-| `lists`          | arr[str] | `[]`, `["myitemize"]` | Extra list environments to be formatted as `itemize` |
-| `verbosity`      | str      | `"warn"`, `"error"`   | Verbosity level for terminal logging |
+| Option           | Type     | Examples               | Description |
+| ---------------- | -------- | ---------------------- | --- |
+| `check`          | bool     | `false`                | Check formatting, do not modify files |
+| `print`          | bool     | `false`                | Print to stdout, do not modify files |
+| `fail-on-change` | bool     | `false`                | Fail if files are modified |
+| `wrap`           | bool     | `true`                 | Wrap long lines |
+| `wraplen`        | int      | `80`, `100`            | Line length for wrapping |
+| `wrapmin`        | int      | `70`, `90`             | Target minimum length for line wrapping |
+| `tabsize`        | int      | `2`, `4`               | Number of characters to use as tab size |
+| `tabchar`        | str      | `"space"`, `"tab"`     | Character to use for indentation |
+| `stdin`          | bool     | `false`                | Process stdin as a single file, output to stdout |
+| `lists`          | arr[str] | `[]`, `["myitemize"]`  | Extra list environments to be formatted as `itemize` |
+| `no-indent-envs` | arr[str] | `[]`, `["mydocument"]` | Environments which are not indented |
+| `verbosity`      | str      | `"warn"`, `"error"`    | Verbosity level for terminal logging |

--- a/notes.org
+++ b/notes.org
@@ -81,6 +81,7 @@
 ** Config arguments
 *** config.rs
 **** Update get_config_args()
+** Implement behaviour
 ** Update README
 *** CLI options
 *** Config options

--- a/notes.org
+++ b/notes.org
@@ -82,6 +82,7 @@
 *** config.rs
 **** Update get_config_args()
 ** Implement behaviour
+** Add tests
 ** Update README
 *** CLI options
 *** Config options

--- a/src/args.rs
+++ b/src/args.rs
@@ -10,6 +10,8 @@ use merge::Merge;
 use std::fmt;
 use std::path::PathBuf;
 
+const DISPLAY_HEADER_WIDTH: usize = 24;
+
 /// Arguments passed to tex-fmt
 #[derive(Debug)]
 pub struct Args {
@@ -248,9 +250,26 @@ fn display_arg_line(
     name: &str,
     value: &str,
 ) -> fmt::Result {
-    let width = 20;
+    let width = DISPLAY_HEADER_WIDTH;
     let name_fmt = format!("{}{}", name.bold(), ":");
     write!(f, "\n  {name_fmt:<width$} {value}")?;
+    Ok(())
+}
+
+/// Display an argument field which is a list of strings
+fn display_args_list(v: &[String], name: &str, f: &mut fmt::Formatter) -> fmt::Result {
+    if !v.is_empty() {
+        display_arg_line(f, name, &v[0])?;
+        for x in &v[1..] {
+            write!(
+                f,
+                "\n  {:<width$} {}",
+                "".bold().to_string(),
+                x,
+                width = DISPLAY_HEADER_WIDTH
+            )?;
+        }
+    }
     Ok(())
 }
 
@@ -275,46 +294,9 @@ impl fmt::Display for Args {
             "verbosity",
             &self.verbosity.to_string().to_lowercase(),
         )?;
-
-        // TODO Write a function for this
-        if !self.lists.is_empty() {
-            display_arg_line(f, "lists", &self.lists[0])?;
-            for file in &self.lists[1..] {
-                write!(
-                    f,
-                    "\n  {:<width$} {}",
-                    "".bold().to_string(),
-                    file,
-                    width = 20
-                )?;
-            }
-        }
-
-        if !self.no_indent_envs.is_empty() {
-            display_arg_line(f, "no-indent-envs", &self.no_indent_envs[0])?;
-            for file in &self.no_indent_envs[1..] {
-                write!(
-                    f,
-                    "\n  {:<width$} {}",
-                    "".bold().to_string(),
-                    file,
-                    width = 20
-                )?;
-            }
-        }
-
-        if !self.files.is_empty() {
-            display_arg_line(f, "files", &self.files[0])?;
-            for file in &self.files[1..] {
-                write!(
-                    f,
-                    "\n  {:<width$} {}",
-                    "".bold().to_string(),
-                    file,
-                    width = 20
-                )?;
-            }
-        }
+        display_args_list(&self.lists, "lists", f)?;
+        display_args_list(&self.no_indent_envs, "no-indent-envs", f)?;
+        display_args_list(&self.files, "files", f)?;
 
         // Do not print `arguments` or `noconfig` fields
         Ok(())

--- a/src/args.rs
+++ b/src/args.rs
@@ -91,18 +91,16 @@ impl fmt::Display for TabChar {
 impl Default for OptionArgs {
     fn default() -> Self {
         let lists = vec![
-                "itemize",
-                "enumerate",
-                "description",
-                "inlineroman",
-                "inventory",
-            ]
-            .into_iter()
-            .map(std::borrow::ToOwned::to_owned)
-            .collect();
-        let no_indent_envs = vec![
-                "document",
-            ]
+            "itemize",
+            "enumerate",
+            "description",
+            "inlineroman",
+            "inventory",
+        ]
+        .into_iter()
+        .map(std::borrow::ToOwned::to_owned)
+        .collect();
+        let no_indent_envs = vec!["document"]
             .into_iter()
             .map(std::borrow::ToOwned::to_owned)
             .collect();
@@ -257,7 +255,11 @@ fn display_arg_line(
 }
 
 /// Display an argument field which is a list of strings
-fn display_args_list(v: &[String], name: &str, f: &mut fmt::Formatter) -> fmt::Result {
+fn display_args_list(
+    v: &[String],
+    name: &str,
+    f: &mut fmt::Formatter,
+) -> fmt::Result {
     if !v.is_empty() {
         display_arg_line(f, name, &v[0])?;
         for x in &v[1..] {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,6 +72,7 @@ pub fn get_cli_args(matches: Option<ArgMatches>) -> OptionArgs {
         config: arg_matches.get_one::<PathBuf>("config").cloned(),
         noconfig: get_flag(&arg_matches, "noconfig"),
         lists: vec![],
+        no_indent_envs: vec![],
         verbosity,
         arguments: get_flag(&arg_matches, "args"),
         files: arg_matches

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,6 +136,13 @@ pub fn get_config_args(
             .iter()
             .filter_map(|v| v.as_str().map(String::from))
             .collect(),
+        no_indent_envs: config
+            .get("no-indent-envs")
+            .and_then(|v| v.as_array())
+            .unwrap_or(&vec![])
+            .iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .collect(),
         verbosity,
         arguments: None,
         files: vec![],

--- a/src/format.rs
+++ b/src/format.rs
@@ -39,16 +39,25 @@ pub fn format_file(
     };
 
     // Get environments to be indented as lists
-    let lists_begin: Vec<String> =
-        args.lists.iter().map(|l| format!("\\begin{{{l}}}")).collect();
+    let lists_begin: Vec<String> = args
+        .lists
+        .iter()
+        .map(|l| format!("\\begin{{{l}}}"))
+        .collect();
     let lists_end: Vec<String> =
         args.lists.iter().map(|l| format!("\\end{{{l}}}")).collect();
 
     // Get environments to be indented as lists
-    let no_indent_envs_begin: Vec<String> =
-        args.no_indent_envs.iter().map(|l| format!("\\begin{{{l}}}")).collect();
-    let no_indent_envs_end: Vec<String> =
-        args.no_indent_envs.iter().map(|l| format!("\\end{{{l}}}")).collect();
+    let no_indent_envs_begin: Vec<String> = args
+        .no_indent_envs
+        .iter()
+        .map(|l| format!("\\begin{{{l}}}"))
+        .collect();
+    let no_indent_envs_end: Vec<String> = args
+        .no_indent_envs
+        .iter()
+        .map(|l| format!("\\end{{{l}}}"))
+        .collect();
 
     loop {
         if let Some((linum_old, mut line)) = queue.pop() {

--- a/src/format.rs
+++ b/src/format.rs
@@ -38,14 +38,17 @@ pub fn format_file(
         TabChar::Space => " ",
     };
 
-    // Get any extra environments to be indented as lists
-    let lists_begin: Vec<String> = args
-        .lists
-        .iter()
-        .map(|l| format!("\\begin{{{l}}}"))
-        .collect();
+    // Get environments to be indented as lists
+    let lists_begin: Vec<String> =
+        args.lists.iter().map(|l| format!("\\begin{{{l}}}")).collect();
     let lists_end: Vec<String> =
         args.lists.iter().map(|l| format!("\\end{{{l}}}")).collect();
+
+    // Get environments to be indented as lists
+    let no_indent_envs_begin: Vec<String> =
+        args.no_indent_envs.iter().map(|l| format!("\\begin{{{l}}}")).collect();
+    let no_indent_envs_end: Vec<String> =
+        args.no_indent_envs.iter().map(|l| format!("\\end{{{l}}}")).collect();
 
     loop {
         if let Some((linum_old, mut line)) = queue.pop() {
@@ -88,6 +91,8 @@ pub fn format_file(
                     &pattern,
                     &lists_begin,
                     &lists_end,
+                    &no_indent_envs_begin,
+                    &no_indent_envs_end,
                 );
 
                 #[allow(clippy::cast_possible_wrap)]

--- a/src/indent.rs
+++ b/src/indent.rs
@@ -45,23 +45,21 @@ fn get_diff(
     pattern: &Pattern,
     lists_begin: &[String],
     lists_end: &[String],
+    no_indent_envs_begin: &[String],
+    no_indent_envs_end: &[String],
 ) -> i8 {
-    // list environments get double indents
+    // indent for environments
     let mut diff: i8 = 0;
-
-    // other environments get single indents
     if pattern.contains_env_begin && line.contains(ENV_BEGIN) {
-        // documents get no global indentation
-        if line.contains(DOC_BEGIN) {
+        if no_indent_envs_begin.iter().any(|r| line.contains(r)) {
             return 0;
-        };
+        }
         diff += 1;
         diff += i8::from(lists_begin.iter().any(|r| line.contains(r)));
     } else if pattern.contains_env_end && line.contains(ENV_END) {
-        // documents get no global indentation
-        if line.contains(DOC_END) {
+        if no_indent_envs_end.iter().any(|r| line.contains(r)) {
             return 0;
-        };
+        }
         diff -= 1;
         diff -= i8::from(lists_end.iter().any(|r| line.contains(r)));
     };
@@ -81,6 +79,7 @@ fn get_back(
     pattern: &Pattern,
     state: &State,
     lists_end: &[String],
+    no_indent_envs_end: &[String],
 ) -> i8 {
     // Only need to dedent if indentation is present
     if state.indent.actual == 0 {
@@ -89,10 +88,9 @@ fn get_back(
     let mut back: i8 = 0;
 
     if pattern.contains_env_end && line.contains(ENV_END) {
-        // documents get no global indentation
-        if line.contains(DOC_END) {
+        if no_indent_envs_end.iter().any(|r| line.contains(r)) {
             return 0;
-        };
+        }
         // list environments get double indents for indenting items
         for r in lists_end {
             if line.contains(r) {
@@ -125,9 +123,11 @@ fn get_indent(
     state: &State,
     lists_begin: &[String],
     lists_end: &[String],
+    no_indent_envs_begin: &[String],
+    no_indent_envs_end: &[String],
 ) -> Indent {
-    let diff = get_diff(line, pattern, lists_begin, lists_end);
-    let back = get_back(line, pattern, state, lists_end);
+    let diff = get_diff(line, pattern, lists_begin, lists_end, no_indent_envs_begin, no_indent_envs_end);
+    let back = get_back(line, pattern, state, lists_end, no_indent_envs_end);
     let actual = prev_indent.actual + diff;
     let visual = prev_indent.actual - back;
     Indent { actual, visual }
@@ -147,6 +147,8 @@ pub fn calculate_indent(
     pattern: &Pattern,
     lists_begin: &[String],
     lists_end: &[String],
+    no_indent_envs_begin: &[String],
+    no_indent_envs_end: &[String],
 ) -> Indent {
     // Calculate the new indent by first removing the comment from the line
     // (if there is one) to ignore diffs from characters in there.
@@ -159,6 +161,8 @@ pub fn calculate_indent(
         state,
         lists_begin,
         lists_end,
+        no_indent_envs_begin,
+        no_indent_envs_end,
     );
 
     // Record the indent to the logs.

--- a/src/indent.rs
+++ b/src/indent.rs
@@ -116,6 +116,7 @@ fn get_back(
 }
 
 /// Calculate indentation properties of the current line
+#[allow(clippy::too_many_arguments)]
 fn get_indent(
     line: &str,
     prev_indent: &Indent,
@@ -126,7 +127,14 @@ fn get_indent(
     no_indent_envs_begin: &[String],
     no_indent_envs_end: &[String],
 ) -> Indent {
-    let diff = get_diff(line, pattern, lists_begin, lists_end, no_indent_envs_begin, no_indent_envs_end);
+    let diff = get_diff(
+        line,
+        pattern,
+        lists_begin,
+        lists_end,
+        no_indent_envs_begin,
+        no_indent_envs_end,
+    );
     let back = get_back(line, pattern, state, lists_end, no_indent_envs_end);
     let actual = prev_indent.actual + diff;
     let visual = prev_indent.actual - back;

--- a/src/regexes.rs
+++ b/src/regexes.rs
@@ -6,10 +6,6 @@ use regex::Regex;
 
 /// Match a LaTeX \item
 pub const ITEM: &str = "\\item";
-/// Match a LaTeX \begin{document}
-pub const DOC_BEGIN: &str = "\\begin{document}";
-/// Match a LaTeX \end{document}
-pub const DOC_END: &str = "\\end{document}";
 /// Match a LaTeX \begin{...}
 pub const ENV_BEGIN: &str = "\\begin{";
 /// Match a LaTeX \end{...}

--- a/tests/no_indent_envs/source/no_indent_envs.tex
+++ b/tests/no_indent_envs/source/no_indent_envs.tex
@@ -14,7 +14,7 @@ This environment is indented.
 
 \begin{myproof}
 
-But not this custom environment
+But not this custom environment.
 
 \end{myproof}
 

--- a/tests/no_indent_envs/source/no_indent_envs.tex
+++ b/tests/no_indent_envs/source/no_indent_envs.tex
@@ -1,0 +1,25 @@
+\documentclass{article}
+
+\begin{document}
+
+Documents are not indented.
+
+\begin{mydocument}
+
+Neither is this environment.
+
+\begin{proof}
+
+This environment is indented.
+
+\begin{myproof}
+
+But not this custom environment
+
+\end{myproof}
+
+\end{proof}
+
+\end{mydocument}
+
+\end{document}

--- a/tests/no_indent_envs/target/no_indent_envs.tex
+++ b/tests/no_indent_envs/target/no_indent_envs.tex
@@ -1,0 +1,25 @@
+\documentclass{article}
+
+\begin{document}
+
+Documents are not indented.
+
+\begin{mydocument}
+
+Neither is this environment.
+
+\begin{proof}
+
+  This environment is indented.
+
+  \begin{myproof}
+
+  But not this custom environment
+
+  \end{myproof}
+
+\end{proof}
+
+\end{mydocument}
+
+\end{document}

--- a/tests/no_indent_envs/target/no_indent_envs.tex
+++ b/tests/no_indent_envs/target/no_indent_envs.tex
@@ -14,7 +14,7 @@ Neither is this environment.
 
   \begin{myproof}
 
-  But not this custom environment
+  But not this custom environment.
 
   \end{myproof}
 

--- a/tests/no_indent_envs/tex-fmt.toml
+++ b/tests/no_indent_envs/tex-fmt.toml
@@ -1,0 +1,1 @@
+no-indent-envs = ["mydocument", "myproof"]

--- a/tex-fmt.toml
+++ b/tex-fmt.toml
@@ -8,3 +8,4 @@ tabchar = "space"
 stdin = false
 verbosity = "warn"
 lists = []
+no-indent-envs = []


### PR DESCRIPTION
This pull request adds a `no-indent-envs` option to the configuration file, which can be used as

```toml
# tex-fmt.toml
no-indent-envs = ["myenvironment", "myproof"]
```

It causes environments as `\begin{myenvironment} ... \end{myenvironment}` to not add extra indentation; this is the same behaviour as `\begin{document} ... \end{document}`.