### PR TITLE
Refactor files arg

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -243,7 +243,7 @@ impl Args {
             };
 
             for dir in &tmp {
-                find_files(dir.into(), &mut self.files);
+                find_files(dir, &mut self.files);
             }
 
             self.files.retain(|e| e.is_file());

--- a/src/args.rs
+++ b/src/args.rs
@@ -242,8 +242,10 @@ impl Args {
                 self.files.clone()
             };
 
-            for dir in &tmp {
-                find_files(dir, &mut self.files);
+            for file in &tmp {
+                if file.is_dir() {
+                    find_files(file, &mut self.files);
+                }
             }
 
             self.files.retain(|e| e.is_file());

--- a/src/args.rs
+++ b/src/args.rs
@@ -234,6 +234,13 @@ impl Args {
             self.wraplen
         };
 
+        // Add .tex to any pathless non-dir file
+        for file in &mut self.files {
+            if !file.is_dir() && file.extension().is_none() {
+                file.set_extension(".tex");
+            }
+        }
+
         // Recursive file search
         if self.recursive {
             let tmp = if self.files.is_empty() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,7 +84,7 @@ pub fn get_cli_args(matches: Option<ArgMatches>) -> OptionArgs {
         files: arg_matches
             .get_many::<String>("files")
             .unwrap_or_default()
-            .map(|e| PathBuf::from(e))
+            .map(PathBuf::from)
             .collect::<Vec<PathBuf>>(),
         recursive: get_flag(&arg_matches, "recursive"),
     };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,8 +84,8 @@ pub fn get_cli_args(matches: Option<ArgMatches>) -> OptionArgs {
         files: arg_matches
             .get_many::<String>("files")
             .unwrap_or_default()
-            .map(ToOwned::to_owned)
-            .collect::<Vec<String>>(),
+            .map(|e| PathBuf::from(e))
+            .collect::<Vec<PathBuf>>(),
         recursive: get_flag(&arg_matches, "recursive"),
     };
     args

--- a/src/format.rs
+++ b/src/format.rs
@@ -13,7 +13,7 @@ use crate::write::process_output;
 use crate::LINE_END;
 use log::Level::{Info, Warn};
 use std::iter::zip;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Central function to format a file
 ///
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 #[allow(clippy::too_many_lines)]
 pub fn format_file(
     old_text: &str,
-    file: &PathBuf,
+    file: &Path,
     args: &Args,
     logs: &mut Vec<Log>,
 ) -> String {
@@ -181,7 +181,7 @@ fn set_ignore_and_report(
     line: &str,
     temp_state: &mut State,
     logs: &mut Vec<Log>,
-    file: &PathBuf,
+    file: &Path,
     pattern: &Pattern,
     verbatims_begin: &[String],
     verbatims_end: &[String],
@@ -320,9 +320,8 @@ pub fn run(args: &Args, logs: &mut Vec<Log>) -> u8 {
     } else {
         for file in &args.files {
             if let Some(text) = read(file, logs) {
-                let new_text = format_file(&text, &file, args, logs);
-                exit_code |=
-                    process_output(args, &file, &text, &new_text, logs);
+                let new_text = format_file(&text, file, args, logs);
+                exit_code |= process_output(args, file, &text, &new_text, logs);
             } else {
                 exit_code = 1;
             }

--- a/src/format.rs
+++ b/src/format.rs
@@ -13,6 +13,7 @@ use crate::write::process_output;
 use crate::LINE_END;
 use log::Level::{Info, Warn};
 use std::iter::zip;
+use std::path::PathBuf;
 
 /// Central function to format a file
 ///
@@ -22,7 +23,7 @@ use std::iter::zip;
 #[allow(clippy::too_many_lines)]
 pub fn format_file(
     old_text: &str,
-    file: &str,
+    file: &PathBuf,
     args: &Args,
     logs: &mut Vec<Log>,
 ) -> String {
@@ -180,7 +181,7 @@ fn set_ignore_and_report(
     line: &str,
     temp_state: &mut State,
     logs: &mut Vec<Log>,
-    file: &str,
+    file: &PathBuf,
     pattern: &Pattern,
     verbatims_begin: &[String],
     verbatims_end: &[String],
@@ -308,15 +309,17 @@ const fn indents_return_to_zero(state: &State) -> bool {
 pub fn run(args: &Args, logs: &mut Vec<Log>) -> u8 {
     let mut exit_code = 0;
     if args.stdin {
-        if let Some((file, text)) = read_stdin(logs) {
-            let new_text = format_file(&text, &file, args, logs);
-            exit_code = process_output(args, &file, &text, &new_text, logs);
+        let stdin_path = PathBuf::from("<stdin>");
+        if let Some(text) = read_stdin(logs) {
+            let new_text = format_file(&text, &stdin_path, args, logs);
+            exit_code =
+                process_output(args, &stdin_path, &text, &new_text, logs);
         } else {
             exit_code = 1;
         }
     } else {
         for file in &args.files {
-            if let Some((file, text)) = read(file, logs) {
+            if let Some(text) = read(file, logs) {
                 let new_text = format_file(&text, &file, args, logs);
                 exit_code |=
                     process_output(args, &file, &text, &new_text, logs);

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -1,5 +1,7 @@
 //! Utilities for ignoring/skipping source lines
 
+use std::path::PathBuf;
+
 use crate::format::State;
 use crate::logging::{record_line_log, Log};
 use log::Level::Warn;
@@ -35,7 +37,7 @@ pub fn get_ignore(
     line: &str,
     state: &State,
     logs: &mut Vec<Log>,
-    file: &str,
+    file: &PathBuf,
     warn: bool,
 ) -> Ignore {
     let skip = contains_ignore_skip(line);

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -1,10 +1,9 @@
 //! Utilities for ignoring/skipping source lines
 
-use std::path::PathBuf;
-
 use crate::format::State;
 use crate::logging::{record_line_log, Log};
 use log::Level::Warn;
+use std::path::Path;
 
 /// Information on the ignored state of a line
 #[derive(Clone, Debug)]
@@ -37,7 +36,7 @@ pub fn get_ignore(
     line: &str,
     state: &State,
     logs: &mut Vec<Log>,
-    file: &PathBuf,
+    file: &Path,
     warn: bool,
 ) -> Ignore {
     let skip = contains_ignore_skip(line);

--- a/src/indent.rs
+++ b/src/indent.rs
@@ -8,7 +8,7 @@ use crate::regexes::{ENV_BEGIN, ENV_END, ITEM, VERB};
 use core::cmp::max;
 use log::Level;
 use log::LevelFilter;
-use std::path::PathBuf;
+use std::path::Path;
 
 /// Opening delimiters
 const OPENS: [char; 3] = ['{', '(', '['];
@@ -166,7 +166,7 @@ pub fn calculate_indent(
     line: &str,
     state: &mut State,
     logs: &mut Vec<Log>,
-    file: &PathBuf,
+    file: &Path,
     args: &Args,
     pattern: &Pattern,
     lists_begin: &[String],

--- a/src/indent.rs
+++ b/src/indent.rs
@@ -8,6 +8,7 @@ use crate::regexes::{ENV_BEGIN, ENV_END, ITEM, VERB};
 use core::cmp::max;
 use log::Level;
 use log::LevelFilter;
+use std::path::PathBuf;
 
 /// Opening delimiters
 const OPENS: [char; 3] = ['{', '(', '['];
@@ -165,7 +166,7 @@ pub fn calculate_indent(
     line: &str,
     state: &mut State,
     logs: &mut Vec<Log>,
-    file: &str,
+    file: &PathBuf,
     args: &Args,
     pattern: &Pattern,
     lists_begin: &[String],

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -8,7 +8,7 @@ use log::Level::{Debug, Error, Info, Trace, Warn};
 use log::LevelFilter;
 use std::cmp::Reverse;
 use std::io::Write;
-use std::path::Path;
+use std::path::PathBuf;
 use web_time::Instant;
 
 /// Holds a log entry
@@ -19,7 +19,7 @@ pub struct Log {
     /// Time when the entry was logged
     pub time: Instant,
     /// File name associated with the entry
-    pub file: String,
+    pub file: PathBuf,
     /// Line number in the formatted file
     pub linum_new: Option<usize>,
     /// Line number in the original file
@@ -34,7 +34,7 @@ pub struct Log {
 fn record_log(
     logs: &mut Vec<Log>,
     level: Level,
-    file: &str,
+    file: &PathBuf,
     linum_new: Option<usize>,
     linum_old: Option<usize>,
     line: Option<String>,
@@ -43,7 +43,7 @@ fn record_log(
     let log = Log {
         level,
         time: Instant::now(),
-        file: file.to_string(),
+        file: file.clone(),
         linum_new,
         linum_old,
         line,
@@ -56,7 +56,7 @@ fn record_log(
 pub fn record_file_log(
     logs: &mut Vec<Log>,
     level: Level,
-    file: &str,
+    file: &PathBuf,
     message: &str,
 ) {
     record_log(logs, level, file, None, None, None, message);
@@ -66,7 +66,7 @@ pub fn record_file_log(
 pub fn record_line_log(
     logs: &mut Vec<Log>,
     level: Level,
-    file: &str,
+    file: &PathBuf,
     linum_new: usize,
     linum_old: usize,
     line: &str,
@@ -195,15 +195,10 @@ pub fn print_logs(logs: &mut Vec<Log>) {
         let log_string = format!(
             "{} {}: {}",
             "tex-fmt".magenta().bold(),
-            match log.file.as_str() {
-                "<stdin>" | "" => "<stdin>".blue().bold(),
-                _ => Path::new(&log.file)
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .blue()
-                    .bold(),
+            if log.file.exists() {
+                log.file.to_str().unwrap().blue().bold()
+            } else {
+                log.file.to_str().unwrap().blue().bold()
             },
             format_log(log),
         );

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -8,7 +8,7 @@ use log::Level::{Debug, Error, Info, Trace, Warn};
 use log::LevelFilter;
 use std::cmp::Reverse;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use web_time::Instant;
 
 /// Holds a log entry
@@ -34,7 +34,7 @@ pub struct Log {
 fn record_log(
     logs: &mut Vec<Log>,
     level: Level,
-    file: &PathBuf,
+    file: &Path,
     linum_new: Option<usize>,
     linum_old: Option<usize>,
     line: Option<String>,
@@ -43,7 +43,7 @@ fn record_log(
     let log = Log {
         level,
         time: Instant::now(),
-        file: file.clone(),
+        file: file.to_path_buf(),
         linum_new,
         linum_old,
         line,
@@ -56,7 +56,7 @@ fn record_log(
 pub fn record_file_log(
     logs: &mut Vec<Log>,
     level: Level,
-    file: &PathBuf,
+    file: &Path,
     message: &str,
 ) {
     record_log(logs, level, file, None, None, None, message);
@@ -66,7 +66,7 @@ pub fn record_file_log(
 pub fn record_line_log(
     logs: &mut Vec<Log>,
     level: Level,
-    file: &PathBuf,
+    file: &Path,
     linum_new: usize,
     linum_old: usize,
     line: &str,
@@ -195,11 +195,7 @@ pub fn print_logs(logs: &mut Vec<Log>) {
         let log_string = format!(
             "{} {}: {}",
             "tex-fmt".magenta().bold(),
-            if log.file.exists() {
-                log.file.to_str().unwrap().blue().bold()
-            } else {
-                log.file.to_str().unwrap().blue().bold()
-            },
+            log.file.to_str().unwrap().blue().bold(),
             format_log(log),
         );
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -5,18 +5,15 @@ use crate::regexes::EXTENSIONS;
 use log::Level::{Error, Trace};
 use std::fs;
 use std::io::Read;
+use std::path::PathBuf;
 
 /// Add a missing extension and read the file
-pub fn read(file: &str, logs: &mut Vec<Log>) -> Option<(String, String)> {
+pub fn read(file: &PathBuf, logs: &mut Vec<Log>) -> Option<String> {
     // Check if file has an accepted extension
     let has_ext = EXTENSIONS.iter().any(|e| file.ends_with(e));
-    // If no valid extension, try adding .tex
-    let mut new_file = file.to_owned();
-    if !has_ext {
-        new_file.push_str(".tex");
-    }
-    if let Ok(text) = fs::read_to_string(&new_file) {
-        return Some((new_file, text));
+
+    if let Ok(text) = fs::read_to_string(file) {
+        return Some(text);
     }
     if has_ext {
         record_file_log(logs, Error, file, "Could not open file.");
@@ -27,23 +24,24 @@ pub fn read(file: &str, logs: &mut Vec<Log>) -> Option<(String, String)> {
 }
 
 /// Attempt to read from stdin, return filename `<stdin>` and text
-pub fn read_stdin(logs: &mut Vec<Log>) -> Option<(String, String)> {
+pub fn read_stdin(logs: &mut Vec<Log>) -> Option<String> {
     let mut text = String::new();
+    let fake_file = PathBuf::from("<stdin>");
     match std::io::stdin().read_to_string(&mut text) {
         Ok(bytes) => {
             record_file_log(
                 logs,
                 Trace,
-                "<stdin>",
+                &fake_file,
                 &format!("Read {bytes} bytes."),
             );
-            Some((String::from("<stdin>"), text))
+            Some(text)
         }
         Err(e) => {
             record_file_log(
                 logs,
                 Error,
-                "<stdin>",
+                &fake_file,
                 &format!("Could not read from stdin: {e}"),
             );
             None

--- a/src/search.rs
+++ b/src/search.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 /// # Panics
 ///
 /// This function panics when a file name cannot be converted to a string.
-pub fn find_files(dir: PathBuf, files: &mut Vec<PathBuf>) {
+pub fn find_files(dir: &PathBuf, files: &mut Vec<PathBuf>) {
     // Recursive walk of passed directory (ignore errors, symlinks and non-dirs)
     if dir.is_dir() {
         for entry in Walk::new(dir).filter_map(std::result::Result::ok) {

--- a/src/search.rs
+++ b/src/search.rs
@@ -7,15 +7,15 @@ use std::path::PathBuf;
 /// # Panics
 ///
 /// This function panics when a file name cannot be converted to a string.
-pub fn find_files(dir: PathBuf, files: &mut Vec<String>) {
+pub fn find_files(dir: PathBuf, files: &mut Vec<PathBuf>) {
     // Recursive walk of passed directory (ignore errors, symlinks and non-dirs)
     if dir.is_dir() {
         for entry in Walk::new(dir).filter_map(std::result::Result::ok) {
             // If entry is file and has accepted extension, push to files
             if entry.file_type().unwrap().is_file() {
-                let file = entry.path().to_str().unwrap();
+                let file = entry.path();
                 if EXTENSIONS.iter().any(|e| file.ends_with(e)) {
-                    files.push(file.to_string());
+                    files.push(file.to_path_buf());
                 }
             }
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -9,14 +9,12 @@ use std::path::PathBuf;
 /// This function panics when a file name cannot be converted to a string.
 pub fn find_files(dir: &PathBuf, files: &mut Vec<PathBuf>) {
     // Recursive walk of passed directory (ignore errors, symlinks and non-dirs)
-    if dir.is_dir() {
-        for entry in Walk::new(dir).filter_map(std::result::Result::ok) {
-            // If entry is file and has accepted extension, push to files
-            if entry.file_type().unwrap().is_file() {
-                let file = entry.path();
-                if EXTENSIONS.iter().any(|e| file.ends_with(e)) {
-                    files.push(file.to_path_buf());
-                }
+    for entry in Walk::new(dir).filter_map(std::result::Result::ok) {
+        // If entry is file and has accepted extension, push to files
+        if entry.file_type().unwrap().is_file() {
+            let file = entry.path();
+            if EXTENSIONS.iter().any(|e| file.ends_with(e)) {
+                files.push(file.to_path_buf());
             }
         }
     }

--- a/src/subs.rs
+++ b/src/subs.rs
@@ -8,6 +8,7 @@ use crate::regexes;
 use crate::LINE_END;
 use log::Level;
 use log::LevelFilter;
+use std::path::PathBuf;
 
 /// Remove multiple line breaks
 #[must_use]
@@ -95,7 +96,7 @@ pub fn needs_split(line: &str, pattern: &Pattern) -> bool {
 pub fn split_line<'a>(
     line: &'a str,
     state: &State,
-    file: &str,
+    file: &PathBuf,
     args: &Args,
     logs: &mut Vec<Log>,
 ) -> (&'a str, &'a str) {

--- a/src/subs.rs
+++ b/src/subs.rs
@@ -8,7 +8,7 @@ use crate::regexes;
 use crate::LINE_END;
 use log::Level;
 use log::LevelFilter;
-use std::path::PathBuf;
+use std::path::Path;
 
 /// Remove multiple line breaks
 #[must_use]
@@ -96,7 +96,7 @@ pub fn needs_split(line: &str, pattern: &Pattern) -> bool {
 pub fn split_line<'a>(
     line: &'a str,
     state: &State,
-    file: &PathBuf,
+    file: &Path,
     args: &Args,
     logs: &mut Vec<Log>,
 ) -> (&'a str, &'a str) {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,8 +10,8 @@ use std::fs;
 use std::path::PathBuf;
 
 fn test_file(
-    source_file: &str,
-    target_file: &str,
+    source_file: &PathBuf,
+    target_file: &PathBuf,
     config_file: Option<&PathBuf>,
     cli_file: Option<&PathBuf>,
 ) -> bool {
@@ -52,8 +52,8 @@ fn test_file(
         println!(
             "{} {} -> {}",
             "fail".red().bold(),
-            source_file.yellow().bold(),
-            target_file.yellow().bold()
+            source_file.to_str().unwrap().yellow().bold(),
+            target_file.to_str().unwrap().yellow().bold()
         );
         let diff = TextDiff::from_lines(&fmt_source_text, &target_text);
         for change in diff.iter_all_changes() {
@@ -108,8 +108,8 @@ fn get_cli_file(dir: &fs::DirEntry) -> Option<PathBuf> {
 }
 
 fn test_source_target(
-    source_file: &str,
-    target_file: &str,
+    source_file: &PathBuf,
+    target_file: &PathBuf,
     config_file: Option<&PathBuf>,
     cli_file: Option<&PathBuf>,
 ) -> bool {
@@ -161,22 +161,20 @@ fn run_tests_in_dir(test_dir: &fs::DirEntry) -> bool {
 
     // Test file formatting
     for file in source_files {
-        let source_file = test_dir.path().join("source").join(file.clone());
-        let source_file = source_file.to_str().unwrap();
-        let target_file = test_dir.path().join("target").join(file.clone());
-        let target_file = target_file.to_str().unwrap();
+        let source_file = test_dir.path().join("source").join(&file);
+        let target_file = test_dir.path().join("target").join(&file);
 
         // If both config and cli exist, either alone should work
         if config_file.is_some() && cli_file.is_some() {
             pass &= test_source_target(
-                source_file,
-                target_file,
+                &source_file,
+                &target_file,
                 config_file.as_ref(),
                 None,
             );
             pass &= test_source_target(
-                source_file,
-                target_file,
+                &source_file,
+                &target_file,
                 None,
                 cli_file.as_ref(),
             );
@@ -184,8 +182,8 @@ fn run_tests_in_dir(test_dir: &fs::DirEntry) -> bool {
 
         // Pass both config and cli, even if one or more are None
         pass &= test_source_target(
-            source_file,
-            target_file,
+            &source_file,
+            &target_file,
             config_file.as_ref(),
             cli_file.as_ref(),
         );

--- a/src/verbatim.rs
+++ b/src/verbatim.rs
@@ -3,7 +3,7 @@
 use crate::format::{Pattern, State};
 use crate::logging::{record_line_log, Log};
 use log::Level::Warn;
-use std::path::PathBuf;
+use std::path::Path;
 
 /// Information on the verbatim state of a line
 #[derive(Clone, Debug)]
@@ -37,7 +37,7 @@ pub fn get_verbatim(
     line: &str,
     state: &State,
     logs: &mut Vec<Log>,
-    file: &PathBuf,
+    file: &Path,
     warn: bool,
     pattern: &Pattern,
     verbatims_begin: &[String],

--- a/src/verbatim.rs
+++ b/src/verbatim.rs
@@ -3,6 +3,7 @@
 use crate::format::{Pattern, State};
 use crate::logging::{record_line_log, Log};
 use log::Level::Warn;
+use std::path::PathBuf;
 
 /// Information on the verbatim state of a line
 #[derive(Clone, Debug)]
@@ -36,7 +37,7 @@ pub fn get_verbatim(
     line: &str,
     state: &State,
     logs: &mut Vec<Log>,
-    file: &str,
+    file: &PathBuf,
     warn: bool,
     pattern: &Pattern,
     verbatims_begin: &[String],

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -28,8 +28,8 @@ pub fn main(text: &str, config: &str) -> JsValue {
     // Run tex-fmt
     let mut logs = Vec::<Log>::new();
     args.resolve(&mut logs);
-    let file = "input";
-    let new_text = format_file(text, file, &args, &mut logs);
+    let file = PathBuf::from("input");
+    let new_text = format_file(text, &file, &args, &mut logs);
     let logs = format_logs(&mut logs, &args);
 
     // Wrap into JS object

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -7,7 +7,7 @@ use crate::logging::{record_line_log, Log};
 use crate::regexes::VERB;
 use log::Level;
 use log::LevelFilter;
-use std::path::PathBuf;
+use std::path::Path;
 
 /// String slice to start wrapped text lines
 pub const TEXT_LINE_START: &str = "";
@@ -107,7 +107,7 @@ pub fn apply_wrap<'a>(
     line: &'a str,
     indent_length: usize,
     state: &State,
-    file: &PathBuf,
+    file: &Path,
     args: &Args,
     logs: &mut Vec<Log>,
     pattern: &Pattern,

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -7,6 +7,7 @@ use crate::logging::{record_line_log, Log};
 use crate::regexes::VERB;
 use log::Level;
 use log::LevelFilter;
+use std::path::PathBuf;
 
 /// String slice to start wrapped text lines
 pub const TEXT_LINE_START: &str = "";
@@ -106,7 +107,7 @@ pub fn apply_wrap<'a>(
     line: &'a str,
     indent_length: usize,
     state: &State,
-    file: &str,
+    file: &PathBuf,
     args: &Args,
     logs: &mut Vec<Log>,
     pattern: &Pattern,

--- a/src/write.rs
+++ b/src/write.rs
@@ -4,18 +4,18 @@ use crate::args::Args;
 use crate::logging::{record_file_log, Log};
 use log::Level::{Error, Info};
 use std::fs;
-use std::path;
+use std::path::PathBuf;
 
 /// Write a formatted file to disk
-fn write_file(file: &str, text: &str) {
-    let filepath = path::Path::new(&file).canonicalize().unwrap();
+fn write_file(file: &PathBuf, text: &str) {
+    let filepath = file.canonicalize().unwrap();
     fs::write(filepath, text).expect("Could not write the file");
 }
 
 /// Handle the newly formatted file
 pub fn process_output(
     args: &Args,
-    file: &str,
+    file: &PathBuf,
     text: &str,
     new_text: &str,
     logs: &mut Vec<Log>,

--- a/src/write.rs
+++ b/src/write.rs
@@ -4,10 +4,10 @@ use crate::args::Args;
 use crate::logging::{record_file_log, Log};
 use log::Level::{Error, Info};
 use std::fs;
-use std::path::PathBuf;
+use std::path::Path;
 
 /// Write a formatted file to disk
-fn write_file(file: &PathBuf, text: &str) {
+fn write_file(file: &Path, text: &str) {
     let filepath = file.canonicalize().unwrap();
     fs::write(filepath, text).expect("Could not write the file");
 }
@@ -15,7 +15,7 @@ fn write_file(file: &PathBuf, text: &str) {
 /// Handle the newly formatted file
 pub fn process_output(
     args: &Args,
-    file: &PathBuf,
+    file: &Path,
     text: &str,
     new_text: &str,
     logs: &mut Vec<Log>,


### PR DESCRIPTION
Refactor the files arg to be a `Vec<PathBuf>`. This makes it so file/dir checks no longer require converting `String` to `Path` or `PathBuf`.

Breaking change:
  - **Breaks**: `tex-fmt paper` formatting `paper.tex`
  - **Reason**: The `read` function no longer appends `.tex` to files without acceptable extensions. Removing it allowed for `read` and `read_stdin` to not return `file` (which in most cases is identical to the passed `file`). I figured it could cause unwanted behavior occasionally since this isn't clearly stated in the readme. If `tex-fmt paper` formatting `paper.tex` is still a desired feature I can put it back in, just let me know.

This simplifies a few things but overall it has very little effect on the code, so if you don't like this new format feel free to reject this PR. If you like the new format but have some suggestions for edits, I'm happy to hear and implement them. 