### PR TITLE
bugfix: fix file extension handling after files refactor to Path/PathBuf

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -237,7 +237,7 @@ impl Args {
         // Add .tex to any pathless non-dir file
         for file in &mut self.files {
             if !file.is_dir() && file.extension().is_none() {
-                file.set_extension(".tex");
+                file.set_extension("tex");
             }
         }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -8,9 +8,14 @@ use std::io::Read;
 use std::path::PathBuf;
 
 /// Add a missing extension and read the file
+///
+/// # Panics
+///
+/// This function panics when a file extension cannot be converted to a string.
 pub fn read(file: &PathBuf, logs: &mut Vec<Log>) -> Option<String> {
     // Check if file has an accepted extension
-    let has_ext = EXTENSIONS.iter().any(|e| file.ends_with(e));
+    let ext = file.extension().unwrap().to_str().unwrap();
+    let has_ext = EXTENSIONS.contains(&ext);
 
     if let Ok(text) = fs::read_to_string(file) {
         return Some(text);

--- a/src/regexes.rs
+++ b/src/regexes.rs
@@ -14,7 +14,7 @@ pub const ENV_BEGIN: &str = "\\begin{";
 pub const ENV_END: &str = "\\end{";
 
 /// Acceptable LaTeX file extensions
-pub const EXTENSIONS: [&str; 4] = [".tex", ".bib", ".sty", ".cls"];
+pub const EXTENSIONS: [&str; 4] = ["tex", "bib", "sty", "cls"];
 /// Match a LaTeX \verb|...|
 pub const VERB: &str = "\\verb|";
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -6,14 +6,15 @@ use std::path::PathBuf;
 ///
 /// # Panics
 ///
-/// This function panics when a file name cannot be converted to a string.
+/// This function panics when a file extension cannot be converted to a string.
 pub fn find_files(dir: &PathBuf, files: &mut Vec<PathBuf>) {
     // Recursive walk of passed directory (ignore errors, symlinks and non-dirs)
     for entry in Walk::new(dir).filter_map(std::result::Result::ok) {
         // If entry is file and has accepted extension, push to files
         if entry.file_type().unwrap().is_file() {
             let file = entry.path();
-            if EXTENSIONS.iter().any(|e| file.ends_with(e)) {
+            let ext = file.extension().unwrap().to_str().unwrap();
+            if EXTENSIONS.contains(&ext) {
                 files.push(file.to_path_buf());
             }
         }


### PR DESCRIPTION
This PR fixes a bug I introduced when doing the refactor of the files arg. Extension handling was still being done as if the files arg was a string, which caused several bugs. This should fix them all. 