### PR TITLE
Fix panic in recursive mode when files without extensions exist

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -13,9 +13,11 @@ pub fn find_files(dir: &PathBuf, files: &mut Vec<PathBuf>) {
         // If entry is file and has accepted extension, push to files
         if entry.file_type().unwrap().is_file() {
             let file = entry.path();
-            let ext = file.extension().unwrap().to_str().unwrap();
-            if EXTENSIONS.contains(&ext) {
-                files.push(file.to_path_buf());
+            if let Some(ext_osstr) = file.extension() {
+                let ext = ext_osstr.to_str().unwrap();
+                if EXTENSIONS.contains(&ext) {
+                    files.push(file.to_path_buf());
+                }
             }
         }
     }


### PR DESCRIPTION
Thanks for your work! This PR fixes a panic in recursive mode due to the existence of a `Makefile`. We should not assume every file has an extension when searching recursively; there can be files without extensions in the directory.
