### PR TITLE
[feat]Support CJK characters wrapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,7 @@ dependencies = [
  "regex",
  "similar",
  "toml",
+ "unicode-width",
  "wasm-bindgen",
  "web-time",
 ]
@@ -675,6 +676,12 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ similar = "2.7.0"
 toml = "0.8.23"
 wasm-bindgen = { version = "0.2.100", optional = true }
 web-time = "1.1.0"
+unicode-width = "0.2.2"
 
 [build-dependencies]
 clap = { version = "4.5.48", features = ["cargo"] }

--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ The following arguments can be passed on the command line.
 | `--completion <SHELL>` |       |         | Generate a shell completion script |
 | `--man`                |       |         | Generate a man page |
 | `--args`               |       |         | View arguments passed to tex-fmt |
+| `--wrap-by-visual-len` |       |         | Use visual length instead of character count when wrapping |
+| `--wrap-cjk`           |       |         | Allow wrap at CJK characters |
 | `--help`               | `-h`  |         | Print help |
 | `--version`            | `-V`  |         | Print version |
 
@@ -388,4 +390,6 @@ The first example in each row is the default value.
 | `verbatims`      | arr[str] | `[]`, `["myverbatim"]` | Extra verbatim environments |
 | `no-indent-envs` | arr[str] | `[]`, `["mydocument"]` | Environments which are not indented |
 | `wrap-chars`     | arr[str] | `[]`, `["。"]`         | Characters after which lines may be wrapped |
+| `wrap-by-visual-len` | bool | `false`                | Use visual length instead of character count when wrapping |
+| `wrap-cjk`       | bool     | `false`                | Allow wrap at CJK characters |
 | `verbosity`      | str      | `"warn"`, `"error"`    | Verbosity level for terminal logging |

--- a/src/args.rs
+++ b/src/args.rs
@@ -53,6 +53,10 @@ pub struct Args {
     pub files: Vec<PathBuf>,
     /// Recursive search for files
     pub recursive: bool,
+    /// Use visual length instead of character count when wrapping
+    pub wrap_by_visual_len: bool,
+    /// Allow wrap at CJK characters
+    pub wrap_cjk: bool,
 }
 
 /// Arguments using Options to track CLI/config file/default values
@@ -97,6 +101,10 @@ pub struct OptionArgs {
     pub files: Vec<PathBuf>,
     #[merge(strategy= merge::option::overwrite_none)]
     pub recursive: Option<bool>,
+    #[merge(strategy= merge::option::overwrite_none)]
+    pub wrap_by_visual_len: Option<bool>,
+    #[merge(strategy= merge::option::overwrite_none)]
+    pub wrap_cjk: Option<bool>,
 }
 
 /// Character to use for indentation
@@ -157,6 +165,8 @@ impl Default for OptionArgs {
             arguments: Some(false),
             files: vec![],
             recursive: Some(false),
+            wrap_by_visual_len: Some(false),
+            wrap_cjk: Some(false),
         }
     }
 }
@@ -184,6 +194,8 @@ impl OptionArgs {
             arguments: None,
             files: vec![],
             recursive: None,
+            wrap_by_visual_len: None,
+            wrap_cjk: None,
         }
     }
 }
@@ -240,6 +252,8 @@ impl Args {
             arguments: args.arguments.unwrap(),
             files: args.files,
             recursive: args.recursive.unwrap(),
+            wrap_by_visual_len: args.wrap_by_visual_len.unwrap(),
+            wrap_cjk: args.wrap_cjk.unwrap(),
         }
     }
 
@@ -377,6 +391,11 @@ impl fmt::Display for Args {
         display_arg_line(f, "wrap", &self.wrap.to_string())?;
         display_arg_line(f, "wraplen", &self.wraplen.to_string())?;
         display_arg_line(f, "wrapmin", &self.wrapmin.to_string())?;
+        display_arg_line(
+            f,
+            "wrap-by-visual-len",
+            &self.wrap_by_visual_len.to_string(),
+        )?;
         display_arg_line(f, "tabsize", &self.tabsize.to_string())?;
         display_arg_line(f, "tabchar", &self.tabchar.to_string())?;
         display_arg_line(f, "stdin", &self.stdin.to_string())?;

--- a/src/args.rs
+++ b/src/args.rs
@@ -391,6 +391,7 @@ impl fmt::Display for Args {
         display_arg_line(f, "wrap", &self.wrap.to_string())?;
         display_arg_line(f, "wraplen", &self.wraplen.to_string())?;
         display_arg_line(f, "wrapmin", &self.wrapmin.to_string())?;
+        display_arg_line(f, "wrap-cjk", &self.wrap_cjk.to_string())?;
         display_arg_line(
             f,
             "wrap-by-visual-len",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,6 +87,8 @@ pub fn get_cli_args(matches: Option<ArgMatches>) -> OptionArgs {
             .map(PathBuf::from)
             .collect::<Vec<PathBuf>>(),
         recursive: get_flag(&arg_matches, "recursive"),
+        wrap_by_visual_len: get_flag(&arg_matches, "wrap-by-visual-len"),
+        wrap_cjk: get_flag(&arg_matches, "wrap-cjk"),
     };
     args
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -132,4 +132,16 @@ pub fn get_cli_command() -> Command {
                 .action(SetTrue)
                 .help("Recursively search for files to format")
         )
+        .arg(
+            Arg::new("wrap-by-visual-len")
+                .long("wrap-by-visual-len")
+                .action(SetTrue)
+                .help("Use visual length instead of character count when wrapping")
+        )
+        .arg(
+            Arg::new("wrap-cjk")
+                .long("wrap-cjk")
+                .action(SetTrue)
+                .help("Allow wrap at CJK characters")
+        )
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,6 +167,10 @@ pub fn get_config_args(
         arguments: None,
         files: vec![],
         recursive: None,
+        wrap_by_visual_len: config
+            .get("wrap-by-visual-len")
+            .map(|x| x.as_bool().unwrap()),
+        wrap_cjk: config.get("wrap-cjk").map(|x| x.as_bool().unwrap()),
     };
     Some(args)
 }

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -8,28 +8,83 @@ use crate::regexes::VERBS;
 use log::Level;
 use log::LevelFilter;
 use std::path::Path;
+use unicode_width::UnicodeWidthChar;
+use unicode_width::UnicodeWidthStr;
 
 /// String slice to start wrapped text lines
 pub const TEXT_LINE_START: &str = "";
 /// String slice to start wrapped comment lines
 pub const COMMENT_LINE_START: &str = "% ";
 
+const CJK_PROHIBITED_AT_START: &[char] = &[
+    '·', '’', '”', '†', '‡', '›', '℃', '：', '、', '。', '〃', '〉', '》',
+    '」', '』', '〕', '〗', '〞', '﹘', '﹚', '﹜', '！', '＂', '％', '＇',
+    '）', '，', '．', '：', '；', '？', '］', '｝', '～', '…', '―'
+];
+
+const CJK_PROHIBITED_AT_END: &[char] = &[
+    '£', '§', '¨', '«', '‘', '“', '〈', '《', '「', '『', '〔', '〖', '〝',
+    '﹙', '﹛', '（', '［', '｛', '￥', '$',
+];
+
 /// Check if a line needs wrapping
 #[must_use]
 pub fn needs_wrap(line: &str, indent_length: usize, args: &Args) -> bool {
-    args.wrap && (line.chars().count() + indent_length > args.wraplen.into())
+    args.wrap
+        && (if args.wrap_by_visual_len {
+            line.width()
+        } else {
+            line.chars().count()
+        } + indent_length
+            > args.wraplen.into())
+}
+
+fn is_cjk_wrap_point(
+    c: char,
+    next_c: Option<char>,
+) -> bool {
+    is_cjk_char(c) 
+        // Next char not prohibited at start
+        && match next_c {
+            Some(c) => !CJK_PROHIBITED_AT_START.contains(&c),
+            None => true,
+        }
+        // this char not prohibited at end
+        && !CJK_PROHIBITED_AT_END.contains(&c)
+        // colon followed by opening quotes is not a wrap point
+        && !matches!((c, next_c), ('：', Some('“' | '「' | '『' | '‘')))
+}
+
+fn is_cjk_char(c: char) -> bool {
+    matches!(c,
+        // CJK Unified Ideographs
+        '\u{4E00}'..='\u{9FFF}'
+        // CJK Unified Ideographs Extension A
+        | '\u{3400}'..='\u{4DBF}'
+        // Hiragana
+        | '\u{3040}'..='\u{309F}'
+        // Katakana
+        | '\u{30A0}'..='\u{30FF}'
+        // Hangul Syllables
+        | '\u{AC00}'..='\u{D7AF}'
+        // CJK Symbols and Punctuation
+        | '\u{3000}'..='\u{303F}'
+    )
 }
 
 fn is_wrap_point(
     i_byte: usize,
     c: char,
     prev_c: Option<char>,
+    next_c: Option<char>,
     inside_verb: bool,
     line_len: usize,
     args: &Args,
 ) -> bool {
+    // wrap at CJK characters if enabled, it will ignore wrap_chars constraint
+    ((args.wrap_cjk && is_cjk_wrap_point(c, next_c)) ||
     // Character c must be a valid wrapping character
-    args.wrap_chars.contains(&c)
+    args.wrap_chars.contains(&c))
         // Must not be preceded by '\'
         && prev_c != Some('\\')
         // Do not break inside a \verb|...|
@@ -80,25 +135,39 @@ fn find_wrap_point(
     let wrap_boundary = usize::from(args.wrapmin) - indent_length;
     let line_len = line.len();
 
-    for (i_char, (i_byte, c)) in line.char_indices().enumerate() {
-        if i_char >= wrap_boundary && wrap_point.is_some() {
+    let mut current_width = 0;
+    // peekable iterator over char indices
+    let mut chars_iter = line.char_indices().peekable();
+
+    while let Some((i_byte, c)) = chars_iter.next() {
+        // cumulative character width
+        current_width += if args.wrap_by_visual_len {
+            c.width().unwrap_or(0)
+        } else {
+            1
+        };
+        // stop if we have exceeded the wrap boundary and found a wrap point
+        if current_width >= wrap_boundary && wrap_point.is_some() {
             break;
         }
         // Special wrapping for lines containing \verb|...|
         let inside_verb =
             is_inside_verb(i_byte, contains_verb, verb_start, verb_end);
-        if is_wrap_point(i_byte, c, prev_c, inside_verb, line_len, args) {
-            if after_non_percent {
-                // Get index of the byte after which
-                // line break will be inserted.
-                // Note this may not be a valid char index.
-                let wrap_byte = i_byte + c.len_utf8() - 1;
-                // Don't wrap here if this is the end of the line anyway
-                if wrap_byte + 1 < line_len {
-                    wrap_point = Some(wrap_byte);
-                }
+        let next_c = chars_iter.peek().map(|(_, c)| *c);
+        if is_wrap_point(i_byte, c, prev_c, next_c, inside_verb, line_len, args)
+            && after_non_percent {
+            // Get index of the byte after which
+            // line break will be inserted.
+            // Note this may not be a valid char index.
+            let wrap_byte = i_byte + c.len_utf8() - 1;
+            // Don't wrap here if this is the end of the line anyway
+            if wrap_byte + 1 < line_len {
+                wrap_point = Some(wrap_byte);
             }
-        } else if c != '%' {
+        }
+        // Unlike English,
+        // a CJK character can be both a wrap point and a non-% character
+        if c != '%' {
             after_non_percent = true;
         }
         prev_c = Some(c);
@@ -132,7 +201,14 @@ pub fn apply_wrap<'a>(
     let comment_index = find_comment_index(line, pattern);
 
     match wrap_point {
-        Some(p) if p <= args.wraplen.into() => {}
+        Some(p) if {
+            // caluculate line visual length if wrap_by_visual_len is enabled
+            (if args.wrap_by_visual_len {
+                line.get(..=p).map_or(0, unicode_width::UnicodeWidthStr::width)
+            } else {
+                p
+            }) <= args.wraplen.into()
+        } => {}
         _ => {
             record_line_log(
                 logs,

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -16,13 +16,15 @@ pub const TEXT_LINE_START: &str = "";
 /// String slice to start wrapped comment lines
 pub const COMMENT_LINE_START: &str = "% ";
 
-const CJK_PROHIBITED_AT_START: &[char] = &[
+// CJK characters that should not appear at the start of a line
+const CJK_CHARS_PROHIBITED_AT_START: &[char] = &[
     '·', '’', '”', '†', '‡', '›', '℃', '：', '、', '。', '〃', '〉', '》',
     '」', '』', '〕', '〗', '〞', '﹘', '﹚', '﹜', '！', '＂', '％', '＇',
     '）', '，', '．', '：', '；', '？', '］', '｝', '～', '…', '―'
 ];
 
-const CJK_PROHIBITED_AT_END: &[char] = &[
+// CJK characters that should not appear at the end of a line
+const CJK_CHARS_PROHIBITED_AT_END: &[char] = &[
     '£', '§', '¨', '«', '‘', '“', '〈', '《', '「', '『', '〔', '〖', '〝',
     '﹙', '﹛', '（', '［', '｛', '￥', '$',
 ];
@@ -46,11 +48,11 @@ fn is_cjk_wrap_point(
     is_cjk_char(c) 
         // Next char not prohibited at start
         && match next_c {
-            Some(c) => !CJK_PROHIBITED_AT_START.contains(&c),
+            Some(c) => !CJK_CHARS_PROHIBITED_AT_START.contains(&c),
             None => true,
         }
         // this char not prohibited at end
-        && !CJK_PROHIBITED_AT_END.contains(&c)
+        && !CJK_CHARS_PROHIBITED_AT_END.contains(&c)
         // colon followed by opening quotes is not a wrap point
         && !matches!((c, next_c), ('：', Some('“' | '「' | '『' | '‘')))
 }

--- a/tex-fmt.toml
+++ b/tex-fmt.toml
@@ -9,3 +9,7 @@ stdin = false
 verbosity = "warn"
 lists = []
 no-indent-envs = []
+
+wrap-by-visual-len = true
+wrap-cjk=true
+# wrap-chars = ["。","，","：","；","！","？","、","．"]

--- a/tex-fmt.toml
+++ b/tex-fmt.toml
@@ -9,7 +9,3 @@ stdin = false
 verbosity = "warn"
 lists = []
 no-indent-envs = []
-
-wrap-by-visual-len = true
-wrap-cjk=true
-# wrap-chars = ["。","，","：","；","！","？","、","．"]


### PR DESCRIPTION
In short, this PR adds two boolean options, `wrap-by-visual-len` and `wrap-cjk`, to improve support for wrapping CJK (**C**hinese, **J**apanese, and **K**orean) text. Both options default to `false` to preserve backward compatibility.

This addresses issue [#103](https://github.com/WGUNDERWOOD/tex-fmt/issues/103).

## `wrap-cjk`

A boolean option that controls whether (almost) all CJK characters can be treated as valid wrap points.

A recent update to the `wrap-chars` option made wrapping at certain CJK punctuation possible, but it still isn’t ideal for CJK users. For example, consider the following text:

```
艾东77挑衅似地将下嘴唇往外一撇，这位萨罗大学的主任正怒气冲冲地瞪着年青的新闻记者。塞尔蒙762在艾东的怒火下从容自如。在早期职业生涯中，他便专长于完成「不可能」的专访，而那时候他现在广为刊载的专栏还只是一个初出茅庐记者脑中疯狂的念头罢了。虽然为此他付出了鼻青脸肿甚至是伤筋断骨的代价，但也因此获得了足够的冷静和自信。

Aton 77, director of Saro University, thrust out a belligerent lower lip and glared at the young newspaperman in a hot fury. Theremon 762 took that fury in his stride. In his earlier days, when his now widely syndicated column was only a mad idea in a cub reporter's mind, he had specialized in 'impossible' interviews. It had cost him bruises, black eyes, and broken bones; but it had given him an ample supply of coolness and self-confidence.
```

With the configuration `wrap-chars = ["，", "。", "；", "：", "！", "？"]`, wrapping only occurs at `，` and `。`:

```
艾东77挑衅似地将下嘴唇往外一撇，这位萨罗大学的主任正怒气冲冲地瞪着年青的新闻记者。塞尔蒙762在艾东的怒火下从容自如。在早期职业生涯中，
他便专长于完成「不可能」的专访，而那时候他现在广为刊载的专栏还只是一个初出茅庐记者脑中疯狂的念头罢了。
虽然为此他付出了鼻青脸肿甚至是伤筋断骨的代价，但也因此获得了足够的冷静和自信。

Aton 77, director of Saro University, thrust out a belligerent lower
lip and glared at the young newspaperman in a hot fury. Theremon 762
took that fury in his stride. In his earlier days, when his now
widely syndicated column was only a mad idea in a cub reporter's
mind, he had specialized in 'impossible' interviews. It had cost him
bruises, black eyes, and broken bones; but it had given him an ample
supply of coolness and self-confidence.
```

But now with `wrap-cjk = true`, CJK text can wrap in a more natural way: almost all CJK characters become valid wrap points, except for certain special punctuation cases:

```
艾东77挑衅似地将下嘴唇往外一撇，这位萨罗大学的主任正怒气冲冲地瞪着年青的新闻记者。塞尔蒙762在艾东的怒火下从容自如。在早期职业生涯
中，他便专长于完成「不可能」的专访，而那时候他现在广为刊载的专栏还只是一个初出茅庐记者脑中疯狂的念头罢了。虽然为此他付出了鼻青脸肿甚至是伤
筋断骨的代价，但也因此获得了足够的冷静和自信。

Aton 77, director of Saro University, thrust out a belligerent lower
lip and glared at the young newspaperman in a hot fury. Theremon 762
took that fury in his stride. In his earlier days, when his now
widely syndicated column was only a mad idea in a cub reporter's
mind, he had specialized in 'impossible' interviews. It had cost him
bruises, black eyes, and broken bones; but it had given him an ample
supply of coolness and self-confidence.
```

## `wrap-by-visual-len`

You may notice that the wrapped Chinese lines above still appear longer than the English ones since Chinese characters are generally twice as wide as English characters. 

The `wrap-by-visual-len` option addresses this by counting visual width (using the [`unicode-width`](https://docs.rs/unicode-width/latest/unicode_width/) crate) instead of the number of characters.

Here is the result with both `wrap-by-visual-len = true` and `wrap-cjk = true`:

```
艾东77挑衅似地将下嘴唇往外一撇，这位萨罗大学的主任正怒气冲冲地瞪着年
青的新闻记者。塞尔蒙762在艾东的怒火下从容自如。在早期职业生涯中，他便
专长于完成「不可能」的专访，而那时候他现在广为刊载的专栏还只是一个初
出茅庐记者脑中疯狂的念头罢了。虽然为此他付出了鼻青脸肿甚至是伤筋断骨
的代价，但也因此获得了足够的冷静和自信。

Aton 77, director of Saro University, thrust out a belligerent lower
lip and glared at the young newspaperman in a hot fury. Theremon 762
took that fury in his stride. In his earlier days, when his now
widely syndicated column was only a mad idea in a cub reporter's
mind, he had specialized in 'impossible' interviews. It had cost him
bruises, black eyes, and broken bones; but it had given him an ample
supply of coolness and self-confidence.

```
