### PR TITLE
wrap: handle verb-like commands without |/+ delimiters without panicking

### DIFF
--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -60,10 +60,15 @@ fn is_inside_verb(
     verb_start: Option<usize>,
     verb_end: Option<usize>,
 ) -> bool {
-    if contains_verb {
-        (verb_start.unwrap() <= i_byte) && (i_byte <= verb_end.unwrap())
-    } else {
-        false
+    if !contains_verb {
+        return false;
+    }
+    // For some verb-like commands (e.g. `\mintinline{...}{...}`) we cannot
+    // locate a `|` / `+` delimiter, so `verb_end` may be `None`. Treat that
+    // as "no protected region" rather than panicking.
+    match (verb_start, verb_end) {
+        (Some(start), Some(end)) => start <= i_byte && i_byte <= end,
+        _ => false,
     }
 }
 


### PR DESCRIPTION
Fixes (edit: partially) #135.

`get_verb_end` searches for `|` or `+` after the verb keyword, which works for `\\verb|...|` and `\\verb+...+` but not for `\\mintinline{lang}{code}`. When `\\mintinline` is on a long line, `verb_end` is `None` while `contains_verb` is true, and `is_inside_verb` panicked on `verb_end.unwrap()`. Treat the missing-end case as 'no protected region'.