### PR TITLE
use modern install-nix-action and cache-nix-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v25
+    - uses: cachix/install-nix-action@31
+    - name: Restore and save Nix store
+      uses: nix-community/cache-nix-action@v7
       with:
-        github_access_token: ${{ secrets.GITHUB_TOKEN }}
-        nix_path: nixpkgs=channel:nixos-unstable
-    - uses: DeterminateSystems/magic-nix-cache-action@main
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-
+        gc-max-store-size-linux: 1G
+        purge: true
+        purge-prefixes: nix-${{ runner.os }}-
+        purge-created: 0
+        purge-last-accessed: P1DT12H
+        purge-primary-key: never
     - run: nix build
     - run: nix flake check --all-systems

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@31
+    - uses: cachix/install-nix-action@v31
     - name: Restore and save Nix store
       uses: nix-community/cache-nix-action@v7
       with:


### PR DESCRIPTION
I looked in previous action runs and noticed the existing cache action is consistently failing, trying to use some external service. I propose we use GitHub's own cachng via `cache-nix-action`. Also updated `install-nix-action` while I'm at it!
