### PR TITLE
fix: index table columns by chars not bytes (#130)

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -15,7 +15,7 @@ fn remove_double_spaces(text: &str) -> String {
 // Add line breaks after "\\"
 fn add_line_breaks(text: &str) -> (String, bool) {
     let re_break = Regex::new(r"\\\\ .*\S").unwrap();
-    let re_indent = Regex::new(r"^\s*\S").unwrap();
+    let re_indent = Regex::new(r"^\s*").unwrap();
     let re_first_non_white = Regex::new(r"\S.*").unwrap();
     let re_to_break = Regex::new(r"^[^\\]*\\\\").unwrap();
     let mut new_text = String::new();
@@ -23,10 +23,7 @@ fn add_line_breaks(text: &str) -> (String, bool) {
     for line in text.lines() {
         if re_break.is_match(line) {
             finished = false;
-            let indent = re_indent.find(line).map_or("", |m| {
-                let s = m.as_str();
-                &s[..s.len() - 1]
-            });
+            let indent = re_indent.find(line).map_or("", |m| m.as_str());
             let next_line_long = re_break.find(line).map_or("", |m| {
                 let s = m.as_str();
                 &s[2..]
@@ -53,7 +50,8 @@ fn get_positions(text: &str) -> Vec<Vec<usize>> {
     text.lines()
         .map(|l| {
             let mut prev = None;
-            l.char_indices()
+            l.chars()
+                .enumerate()
                 .filter_map(|(i, c)| {
                     let is_match = c == '&' && prev != Some('\\');
                     prev = Some(c);

--- a/tests/tables/source/unicode_tables.tex
+++ b/tests/tables/source/unicode_tables.tex
@@ -1,0 +1,19 @@
+\begin{document}
+
+\begin{center}
+  \begin{tabular}{lr}
+    german & english \\
+    rot & red \\
+    grün & green \\
+    gelb & yellow \\
+    türkis & torquoise \\
+  \end{tabular}
+\end{center}
+
+\begin{center}
+  \begin{tabular}{ll}
+    über & over \\ rot & red \\
+  \end{tabular}
+\end{center}
+
+\end{document}

--- a/tests/tables/target/unicode_tables.tex
+++ b/tests/tables/target/unicode_tables.tex
@@ -1,0 +1,20 @@
+\begin{document}
+
+\begin{center}
+  \begin{tabular}{lr}
+    german & english \\
+    rot    & red \\
+    grün   & green \\
+    gelb   & yellow \\
+    türkis & torquoise \\
+  \end{tabular}
+\end{center}
+
+\begin{center}
+  \begin{tabular}{ll}
+    über & over \\
+    rot  & red \\
+  \end{tabular}
+\end{center}
+
+\end{document}


### PR DESCRIPTION
## Problem
Fixes #130. Table columns containing multi-byte UTF-8 characters (e.g. `grün`, `türkis`) get misaligned by one space per multi-byte character. A related bug in the same function also panics: a table row that needs a line break (`\\\\` followed by more content) panics if the line's first non-whitespace character is multi-byte. Confirmed on master HEAD 0b68b2e.

## Root cause
`src/table.rs`, two spots, one root cause: column widths and indentation are computed with byte offsets/lengths instead of character counts.

- `get_positions` uses `l.char_indices()`, which yields the byte offset of each `&`. That offset is later used as a count of *columns* to pad with spaces (`format_table_line`), so every multi-byte char before an `&` inflates the padding by `len_utf8() - 1`.
- `add_line_breaks` computes an indent prefix as `&s[..s.len() - 1]`, slicing off what it assumes is a single trailing ASCII byte. If that byte boundary falls inside a multi-byte character, this panics (`byte index N is not a char boundary`).

## Fix
Use `l.chars().enumerate()` instead of `char_indices()` so column positions are counted in characters, not bytes. Simplify the indent regex to `^\\s*` (matched only when the line is known non-whitespace via the caller's `re_break` guard) and take `m.as_str()` directly instead of byte-slicing off the last byte. 3 lines changed, no API changes.

## How to test
```
$ printf '\\begin{tabular}{lr}\n  german & english \\\\\n  gr\u00fcn & green \\\\\n\\end{tabular}\n' > t.tex
$ tex-fmt --format-tables --print t.tex   # before fix: gr\u00fcn column short by one space

$ printf '\\begin{tabular}\n  \u00fcber & over \\\\ rot & red \\\\\n\\end{tabular}\n' > p.tex
$ tex-fmt --format-tables --print p.tex   # before fix: panics with "byte index N is not a char boundary"
```
Added a regression fixture (`tests/tables/source/unicode_tables.tex` -> `tests/tables/target/unicode_tables.tex`) covering both cases via the existing `test_all` harness. Proven to bite: with the fix reverted (fixture kept), `cargo test --release test_all` fails — first on a wrong-alignment diff, then panics at `src/table.rs:28` on the second case. With the fix applied, it passes.

Full suite: `cargo test --release` green. `cargo clippy --release --all-targets`: no new warnings (pre-existing `map_unwrap_or` warning in `src/config.rs` is unrelated to this diff). `cargo fmt --check`: clean.

## Backward compatibility
No breaking changes. Output only changes for table cells containing multi-byte UTF-8 characters, which were previously misaligned or caused a panic.

---
Assisted-by: Claude (code generation, reviewed and tested locally)